### PR TITLE
71 efeitos de timecycle só devem afetar ambientes externos

### DIFF
--- a/Game-Loot-Lunch/levels/Dungeon_Way/dungeon_way.gd
+++ b/Game-Loot-Lunch/levels/Dungeon_Way/dungeon_way.gd
@@ -7,6 +7,7 @@ signal player_can_enter_external_house
 signal player_can_enter_shop
 
 
+@export var is_outdoor: bool = true
 @export var player_start_position : Marker2D
 
 
@@ -14,6 +15,9 @@ signal player_can_enter_shop
 
 
 func _ready() -> void:
+	
+	EnvironmentManager.is_outdoor = is_outdoor
+	
 	if not player_start_position:
 		player.position = Vector2(35,305)
 	else:

--- a/Game-Loot-Lunch/levels/external_dungeon/dungeon_exterior.gd
+++ b/Game-Loot-Lunch/levels/external_dungeon/dungeon_exterior.gd
@@ -10,6 +10,7 @@ signal player_can_enter_shop
 signal stop_player_can_enter_shop
 
 
+@export var is_outdoor: bool = true
 @export var player_start_position : Marker2D
 @export var internal_dungeon_entrance : Marker2D 
 @export var dungeon_way_entrance : Marker2D  
@@ -19,6 +20,9 @@ signal stop_player_can_enter_shop
 
 
 func _ready() -> void:
+	
+	EnvironmentManager.is_outdoor = is_outdoor
+	
 	if not player_start_position:
 		player.position = Vector2(35, 305)
 	else:

--- a/Game-Loot-Lunch/levels/external_house/external_house.gd
+++ b/Game-Loot-Lunch/levels/external_house/external_house.gd
@@ -9,6 +9,7 @@ signal player_can_enter_combat_area
 signal stop_player_can_enter_combat_area
 
 
+@export var is_outdoor: bool = true
 @export var player_start_position : Marker2D
 
 
@@ -18,6 +19,9 @@ signal stop_player_can_enter_combat_area
 
 
 func _ready() -> void:
+	
+	EnvironmentManager.is_outdoor = is_outdoor
+	
 	if not player_start_position:
 		player.position = Vector2(35,305)
 	else:

--- a/Game-Loot-Lunch/levels/internal_dungeon/internal_dungeon.gd
+++ b/Game-Loot-Lunch/levels/internal_dungeon/internal_dungeon.gd
@@ -2,8 +2,14 @@ extends Node2D
 class_name InternalDungeon
 
 
+@export var is_outdoor: bool = false
+
+
 signal player_can_leave_dungeon
 
 
 func _on_external_house_interact_with_player() -> void:
 	player_can_leave_dungeon.emit()
+
+func _ready() -> void:
+	EnvironmentManager.is_outdoor = is_outdoor

--- a/Game-Loot-Lunch/levels/internal_house/inside_house.gd
+++ b/Game-Loot-Lunch/levels/internal_house/inside_house.gd
@@ -1,6 +1,10 @@
 extends Node2D
 class_name InsideHouse
 
+
+@export var is_outdoor: bool = false
+
+
 signal player_can_leave_house
 signal stop_player_can_leave_house
 
@@ -11,3 +15,6 @@ func _on_door_area_entered() -> void:
 
 func _on_door_area_exited() -> void:
 	stop_player_can_leave_house.emit()
+
+func _ready() -> void:
+	EnvironmentManager.is_outdoor = is_outdoor

--- a/Game-Loot-Lunch/levels/shop/shop_room.gd
+++ b/Game-Loot-Lunch/levels/shop/shop_room.gd
@@ -4,6 +4,7 @@ extends Node2D
 signal player_can_leave_shop
 signal stop_player_can_leave_shop
 
+@export var is_outdoor: bool = false
 @export var shop_menu: ShopMenu
 @export var shop_component: ShopComponent
 @export var player_inventory_component: InventoryComponent
@@ -12,6 +13,9 @@ signal stop_player_can_leave_shop
 
 
 func _ready() -> void:
+	
+	EnvironmentManager.is_outdoor = is_outdoor
+	
 	shop_menu.shop_opened.connect(_on_shop_menu_opened)
 	shop_menu.shop_closed.connect(_on_shop_menu_closed)
 	player_inventory_component.inventory_opened.connect(_on_player_inventory_opened)

--- a/Game-Loot-Lunch/menus/main/main_menu.gd
+++ b/Game-Loot-Lunch/menus/main/main_menu.gd
@@ -12,6 +12,8 @@ extends Control
 ## [b]Se vazio:[/b] O jogo fecha imediatamente após o clique.
 @export var press_sound: AudioStream
 
+@export var is_outdoor: bool = false
+
 var is_quitting: bool = false
 
 var save_load_menu: SaveLoadMenu
@@ -27,6 +29,7 @@ var save_load_scene: PackedScene = preload("res://menus/saver_loader/save_load_m
 
 
 func _ready() -> void:
+	EnvironmentManager.is_outdoor = is_outdoor
 	hover_audio.stream = hover_sound
 	press_audio.stream = press_sound
 

--- a/Game-Loot-Lunch/project.godot
+++ b/Game-Loot-Lunch/project.godot
@@ -26,6 +26,7 @@ SaveLoadManager="*uid://bi06j1t67d10f"
 EasyTransition="*uid://cq0t7o8xelk4k"
 DayNightCycle="*uid://yr26mvbasy76"
 PlayerWallet="*uid://bs1b836vdqxr4"
+EnvironmentManager="*uid://cx07gbanpuo6o"
 
 [debug]
 

--- a/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.gd
+++ b/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.gd
@@ -47,21 +47,13 @@ func _process(delta: float) -> void:
 
 
 func _on_day_started() -> void:
-	if !EnvironmentManager.is_outdoor:
-		return
-	
 	_target_color = day_color
-
 	_day_target_volume = 0.0
 	_night_target_volume = -40.0
 
 
 func _on_night_started() -> void:
-	if !EnvironmentManager.is_outdoor:
-		return
-
 	_target_color = night_color
-
 	_day_target_volume = -40.0
 	_night_target_volume = 0.0
 

--- a/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.gd
+++ b/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.gd
@@ -21,11 +21,11 @@ var _night_target_volume: float = -40.0
 func _ready() -> void:
 	TimeCycle.day_started.connect(_on_day_started)
 	TimeCycle.night_started.connect(_on_night_started)
+	EnvironmentManager.outdoor_changed.connect(_on_outdoor_changed)
 
 	_target_color = color
 
-	_day_ambient.play()
-	_night_ambient.play()
+	_on_outdoor_changed(EnvironmentManager.is_outdoor)
 
 
 func _process(delta: float) -> void:
@@ -47,6 +47,9 @@ func _process(delta: float) -> void:
 
 
 func _on_day_started() -> void:
+	if !EnvironmentManager.is_outdoor:
+		return
+	
 	_target_color = day_color
 
 	_day_target_volume = 0.0
@@ -54,7 +57,26 @@ func _on_day_started() -> void:
 
 
 func _on_night_started() -> void:
+	if !EnvironmentManager.is_outdoor:
+		return
+
 	_target_color = night_color
 
 	_day_target_volume = -40.0
 	_night_target_volume = 0.0
+
+
+func _on_outdoor_changed(is_outdoor: bool) -> void:
+	visible = is_outdoor
+
+	if is_outdoor:
+		_day_ambient.play()
+		_night_ambient.play()
+
+		if TimeCycle.is_day():
+			_on_day_started()
+		else:
+			_on_night_started()
+	else:
+		_day_ambient.stop()
+		_night_ambient.stop()

--- a/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.tscn
+++ b/Game-Loot-Lunch/systems/TimeCycle/day_night_cycle.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="AudioStream" uid="uid://cws2chg3v21hb" path="res://assets/sfx/ambient/freesound_community-night-ambience-17064.mp3" id="3_daak6"]
 
 [node name="CanvasModulate" type="CanvasModulate" unique_id=2007590606]
+visible = false
 color = Color(0.75375223, 0.8162061, 0.93515855, 1)
 script = ExtResource("1_ry3t4")
 

--- a/Game-Loot-Lunch/systems/TimeCycle/environment_manager.gd
+++ b/Game-Loot-Lunch/systems/TimeCycle/environment_manager.gd
@@ -1,0 +1,11 @@
+extends Node
+
+signal outdoor_changed(is_outdoor: bool)
+
+var is_outdoor : bool = true:
+	set(value):
+		if is_outdoor == value:
+			return
+
+		is_outdoor = value
+		outdoor_changed.emit(value)

--- a/Game-Loot-Lunch/systems/TimeCycle/environment_manager.gd.uid
+++ b/Game-Loot-Lunch/systems/TimeCycle/environment_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://cx07gbanpuo6o


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Closes #71 - [Efeitos de TimeCycle só devem afetar ambientes externos](https://github.com/GameLab-UERJ/Loot-Lunch/issues/71)

Implementa um sistema global de identificação de ambientes internos e externos por meio do `EnvironmentManager` (autoload singleton), permitindo que os efeitos do ciclo de dia e noite sejam aplicados apenas em áreas externas.

Todos os Levels agora expõem uma propriedade `is_outdoor`, utilizada para informar ao `EnvironmentManager` o tipo de ambiente atual. O `day_night_cycle` passou a responder às mudanças de ambiente, ocultando o `CanvasModulate` e interrompendo os sons ambientes quando o jogador entra em um interior.

Também foi corrigido um problema em que o estado interno do ciclo de dia e noite deixava de ser atualizado enquanto o jogador permanecia em ambientes internos, fazendo com que o horário ao retornar para o exterior pudesse ficar incorreto.

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ ✔️ ] Lógica (.gd): Scripts alterados/adicionados.

[ ✔️ ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ ❌ ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ ❌ ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ ✔️ ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ ✔️ ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ ✔️ ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ ✔️ ] Testado no Editor (Desktop).

[ ❌ ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).