### PR TITLE
15 alguns items são stackaveiss

### DIFF
--- a/Game-Loot-Lunch/entities/base_classes/item/item.gd
+++ b/Game-Loot-Lunch/entities/base_classes/item/item.gd
@@ -11,6 +11,9 @@ signal picked_up(item : Item)
 @export var item_name : String		## Name of the Item
 @export var description : String	## Description of the Item, to e shown when inspected
 @export var is_ingredient : bool	## Ingredients can be used in recipees
+## Quantas unidades este Item representa quando dropado no mundo.
+## Default 1; para stacks, pode ser > 1.
+var dropped_count: int = 1
 
 
 @onready var clickable_area: ClickableArea = get_node("ClickableArea") if has_node("ClickableArea") else null

--- a/Game-Loot-Lunch/entities/base_classes/stackable_component.gd
+++ b/Game-Loot-Lunch/entities/base_classes/stackable_component.gd
@@ -1,0 +1,5 @@
+extends Node
+class_name StackableComponent
+
+
+@export var stack_size: int = 5

--- a/Game-Loot-Lunch/entities/base_classes/stackable_component.gd.uid
+++ b/Game-Loot-Lunch/entities/base_classes/stackable_component.gd.uid
@@ -1,0 +1,1 @@
+uid://c3lm5ccn6h1rs

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -37,8 +37,6 @@ var selected_pos : Vector2i:
 
 func _ready() -> void:
 	dimensions = dimensions
-	for cell: InventoryCell in grid.get_children():
-		cell.split_stack.connect(_handle_split_stack)
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -124,6 +124,12 @@ func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
 		return
 	
 	# Caso 3: Swap — tipos diferentes
+	# Se a source ainda tem unidades virtuais (pick-up parcial),
+	# não dá pra fazer swap limpo — retorna o carry pra source.
+	if source.count > 0:
+		set_selected_cell(null)
+		return
+	
 	var tgt_item: Item = target.item
 	var tgt_count: int = target.count
 	

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -20,15 +20,12 @@ signal cell_left_clicked(cell : InventoryCell)
 
 var selected_cell : InventoryCell
 ## Item físico seguindo o mouse (pickup total / split).
-## Fica null quando é pickup parcial (ghost).
+## Fica null quando não há seleção.
 var selected_item : Item
 ## Quantas unidades estamos carregando.
 var selected_count : int = 0
 var selected_pos : Vector2i:
 	get = get_selected_pos
-
-## Fantasma visual para pickup parcial (quando o Item fica na célula).
-var _ghost: Sprite2D = null
 
 
 @onready var container: PanelContainer = $Container
@@ -38,10 +35,6 @@ var _ghost: Sprite2D = null
 func _ready() -> void:
 	dimensions = dimensions
 
-
-func _process(_delta: float) -> void:
-	if _ghost:
-		_ghost.global_position = get_global_mouse_position()
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -101,7 +94,6 @@ func _try_merge(source: InventoryCell, target: InventoryCell, src_item: Item, sr
 		selected_item = null
 		selected_count = 0
 		src_item.queue_free()
-		_remove_ghost()
 		return true
 	
 	selected_count = src_count
@@ -120,7 +112,6 @@ func _place_on_empty(source: InventoryCell, target: InventoryCell, src_item: Ite
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
-	_remove_ghost()
 
 
 func _do_swap(source: InventoryCell, target: InventoryCell, src_item: Item, src_count: int) -> void:
@@ -155,13 +146,13 @@ func handle_new_selected_cell(cell : InventoryCell) -> void:
 		set_selected_cell(null)
 		return
 	
-	# --- Tem um item/ghost selecionado, clicou em outra célula ---
+	# --- Tem um item selecionado, clicou em outra célula ---
 	
 	var source = selected_cell
 	var src_count = selected_count
 	var src_item = selected_item
 	
-	# Se for ghost (pickup parcial), o Item ainda está na source
+	# Se for pickup parcial ou split, o original ainda está na source
 	if not src_item:
 		src_item = source.item
 	
@@ -173,7 +164,7 @@ func handle_new_selected_cell(cell : InventoryCell) -> void:
 	if _try_merge(source, cell, src_item, src_count):
 		return
 	
-	# Ghost (pickup parcial) só pode merge ou cancelar
+	# Se não tem selected_item (segurança), cancela
 	if not selected_item:
 		# Return to source
 		set_selected_cell(null)
@@ -186,7 +177,7 @@ func handle_new_selected_cell(cell : InventoryCell) -> void:
 	
 	# Com Item físico: swap
 	if source.count > 0:
-		# Source tem unidades virtuais — não pode swap limpo
+		# Source tem unidades remanescentes — não pode swap
 		set_selected_cell(null)
 		return
 	
@@ -268,68 +259,46 @@ func drop_selected_item() -> void:
 	if not selected_cell:
 		return
 	
+	if not selected_item:
+		return
+	
 	if not node_to_drop:
 		push_error("No node_to_drop set. Cannot drop item.")
-		if _ghost:
+		if selected_cell.item:
 			selected_cell.count += selected_count
-		elif selected_item:
+			selected_item.queue_free()
+		else:
 			selected_cell.set_item(selected_item)
 			selected_cell.count = selected_count
 		_cleanup_selection()
 		return
 	
-	# Ghost (pickup parcial) — só restaura
-	if _ghost:
-		selected_cell.count += selected_count
-		_cleanup_selection()
-		return
-	
-	# Item físico seguindo o mouse — dropa no mundo
-	if selected_item:
-		selected_cell.is_selected = false
-		selected_item.global_position = node_to_drop.global_position
-		selected_item.show()
-		selected_item.force_stop_follow_mouse()
-		selected_item.top_level = false
-		selected_item.z_index = 0
-		_cleanup_selection()
+	selected_cell.is_selected = false
+	selected_item.global_position = node_to_drop.global_position
+	selected_item.show()
+	selected_item.force_stop_follow_mouse()
+	selected_item.top_level = false
+	selected_item.z_index = 0
+	_cleanup_selection()
 
 
 func _cleanup_selection() -> void:
-	_remove_ghost()
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
-
-
-func _create_ghost(source: InventoryCell) -> void:
-	if not source.item:
-		return
-	_ghost = Sprite2D.new()
-	_ghost.texture = source.item.texture
-	_ghost.region_enabled = source.item.region_enabled
-	_ghost.region_rect = source.item.region_rect
-	_ghost.scale = source.item.scale
-	_ghost.top_level = true
-	_ghost.z_index = 100
-	add_child(_ghost)
-
-
-func _remove_ghost() -> void:
-	if _ghost:
-		_ghost.queue_free()
-		_ghost = null
 
 
 func set_selected_cell(value: InventoryCell) -> void:
 	if selected_cell:
 		selected_cell.is_selected = false
 		if selected_item:
-			var remaining: int = selected_cell.count
-			selected_cell.set_item(selected_item)
-			selected_cell.count = remaining + selected_count
+			if selected_cell.item:
+				selected_cell.count += selected_count
+				selected_item.queue_free()
+			else:
+				selected_cell.set_item(selected_item)
+				selected_cell.count = selected_count
 			selected_item = null
-		_remove_ghost()
 		selected_count = 0
 	
 	selected_cell = value
@@ -345,11 +314,14 @@ func set_selected_cell(value: InventoryCell) -> void:
 	var cell_count = selected_cell.count
 	
 	if is_stackable and cell_count > 1 and not Input.is_key_pressed(KEY_SHIFT):
-		# Pickup parcial: Item fica na célula, ghost visual segue o mouse
+		# Pickup parcial: duplica o Item, original fica na célula
 		selected_count = 1
 		selected_cell.count -= 1
-		selected_item = null
-		_create_ghost(selected_cell)
+		selected_item = selected_cell.item.duplicate()
+		add_child(selected_item)
+		selected_item.top_level = true
+		selected_item.z_index = 100
+		selected_item.force_follow_mouse()
 	else:
 		# Pickup total: Item sai da célula e segue o mouse
 		selected_count = cell_count
@@ -367,10 +339,13 @@ func _handle_split_stack(cell: InventoryCell, half: int) -> void:
 	if half <= 0 or half >= cell.count:
 		return
 	
+	# Split: duplica o Item, original fica na célula
+	var new_item = cell.item.duplicate()
+	add_child(new_item)
+	
 	cell.count -= half
 	
-	# Split pega o Item da célula (metade da stack)
-	selected_item = cell.remove_item_for_stack(self)
+	selected_item = new_item
 	selected_cell = cell
 	selected_count = half
 	

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -42,9 +42,16 @@ func _process(_delta: float) -> void:
 	if not selected_cell or not selected_item:
 		return
 	
-	# Só age se o clique foi FORA do inventário
-	var inside = Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position())
-	if inside:
+	# Só dropa se o clique foi FORA das células (grid)
+	var on_cell = false
+	var mouse_global = get_global_mouse_position()
+	for cell in grid.get_children():
+		var cell_rect = Rect2(cell.global_position, cell.size)
+		if cell_rect.has_point(mouse_global):
+			on_cell = true
+			break
+	
+	if on_cell:
 		return
 	
 	drop_selected_item()

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -268,6 +268,16 @@ func drop_selected_item() -> void:
 	if not selected_cell:
 		return
 	
+	if not node_to_drop:
+		push_error("No node_to_drop set. Cannot drop item.")
+		if _ghost:
+			selected_cell.count += selected_count
+		elif selected_item:
+			selected_cell.set_item(selected_item)
+			selected_cell.count = selected_count
+		_cleanup_selection()
+		return
+	
 	# Ghost (pickup parcial) — só restaura
 	if _ghost:
 		selected_cell.count += selected_count
@@ -277,8 +287,7 @@ func drop_selected_item() -> void:
 	# Item físico seguindo o mouse — dropa no mundo
 	if selected_item:
 		selected_cell.is_selected = false
-		if node_to_drop:
-			selected_item.global_position = node_to_drop.global_position
+		selected_item.global_position = node_to_drop.global_position
 		selected_item.show()
 		selected_item.force_stop_follow_mouse()
 		selected_item.top_level = false

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -23,6 +23,10 @@ signal cell_left_clicked(cell : InventoryCell)
 
 var selected_cell : InventoryCell
 var selected_item : Item
+## Quantas unidades do item estão atualmente selecionadas/seguindo o mouse.
+## Para não-stackáveis ou full-stack, = cell.count original.
+## Para pick-up parcial (1 unidade de um stack), = 1.
+var selected_count : int = 0
 var selected_pos : Vector2i:
 	get = get_selected_pos
 
@@ -33,6 +37,8 @@ var selected_pos : Vector2i:
 
 func _ready() -> void:
 	dimensions = dimensions
+	for cell: InventoryCell in grid.get_children():
+		cell.split_stack.connect(_handle_split_stack)
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -43,7 +49,8 @@ func _gui_input(event: InputEvent) -> void:
 	
 	if event.is_action_released("right_click"):
 		if selected_cell:
-			handle_new_selected_cell(null)
+			drop_selected_item()
+
 
 func set_dimensions(value : Vector2i) -> void:
 	if not value or not(value.x != 0 and value.y != 0):
@@ -58,6 +65,7 @@ func set_dimensions(value : Vector2i) -> void:
 			cell = INVENTORY_CELL.instantiate()
 			cell.left_clicked.connect(handle_cell_left_clicked)
 			cell.wants_item_removed.connect(handle_wants_item_removed)
+			cell.split_stack.connect(_handle_split_stack)
 			grid.add_child(cell)
 		call_deferred("remove_empty_cells",grid.get_child_count()-dimensions.x * dimensions.y)
 
@@ -68,13 +76,73 @@ func handle_cell_left_clicked(cell : InventoryCell) -> void:
 		handle_new_selected_cell(cell)
 
 
+## Troca o item entre selected_cell e a célula do parâmetro,
+## fazendo merge se forem do mesmo tipo stackável.
+func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
+	var source_item: Item = selected_item
+	var source_count: int = selected_count
+	
+	if not source_item:
+		push_warning("No item to place")
+		return
+	
+	# Merge: mesmo tipo e stackável e com espaço
+	if target.item and target.item.item_name == source_item.item_name and target.is_stackable():
+		var stack_comp = target.item.get_node("StackableComponent")
+		if not stack_comp:
+			# Fallback: swap normal
+			_do_swap(source, target, source_item, source_count)
+			return
+		var space = stack_comp.stack_size - target.count
+		if space > 0:
+			var move = mini(source_count, space)
+			target.count += move
+			source_count -= move
+			
+			if source_count <= 0:
+				source.count = 0
+				source.is_selected = false
+				source.item = null
+				selected_cell = null
+				selected_item = null
+				selected_count = 0
+				source_item.queue_free()
+				return
+			else:
+				# Ainda sobrou unidade na mão — mantém seleção
+				selected_count = source_count
+				source.is_selected = false
+				return
+		# Sem espaço, cai no swap normal
+	
+	# Swap normal (ou target com tipo diferente)
+	_do_swap(source, target, source_item, source_count)
+
+
+func _do_swap(source: InventoryCell, target: InventoryCell, source_item: Item, source_count: int) -> void:
+	var target_item: Item = target.item
+	var target_count: int = target.count
+	
+	target.item = source_item
+	target.count = source_count
+	
+	source.item = target_item
+	source.count = target_count
+	
+	source.is_selected = false
+	target.is_selected = false
+	selected_cell = null
+	selected_item = null
+	selected_count = 0
+
+
 ## Returns an array with the references of all empty cells
 ## [br]
 ## if 'first' is true, returns as soon as it finds one
 func find_empty_cells(first : bool = false) -> Array[InventoryCell]:
 	var result : Array[InventoryCell] = []
 	for cell : InventoryCell in grid.get_children():
-		if not cell.item:
+		if not cell.item and cell.count <= 0:
 			result.append(cell)
 			if first:
 				break
@@ -107,12 +175,15 @@ func handle_wants_item_removed(cell : InventoryCell) -> void:
 	else:
 		push_error("Node where to drop items is not set. Dropped at position zero of ",item.get_parent())
 
+
 func handle_new_selected_cell(cell : InventoryCell) -> void:
 	if not cell:
+		# Chamado com null = cancelar/deselect (retorna item pra célula)
 		set_selected_cell(null)
 		return
 	
 	if not selected_cell:
+		# Nada selecionado ainda — tenta selecionar esta célula
 		if not cell.item:
 			cell.is_selected = false
 			return
@@ -120,21 +191,39 @@ func handle_new_selected_cell(cell : InventoryCell) -> void:
 		return
 	
 	if selected_cell == cell:
-		handle_new_selected_cell(null)
+		# Clicou na mesma célula = deselect (retorna o item)
+		set_selected_cell(null)
 		return
-		
-	selected_cell.item = cell.item
-	cell.item = selected_item
-
-	cell.is_selected = false
-	selected_cell.is_selected = false
-	selected_cell = null
-	selected_item = null
+	
+	# Tem um item selecionado e clicou em outra célula
+	_swap_or_merge(selected_cell, cell)
 
 
+## Adiciona um Item ao inventário.
+## Se o item for stackável, tenta empilhar em células existentes
+## do mesmo tipo antes de colocar numa célula vazia.
 func add_item(item : Item) -> void:
-	var cell : InventoryCell = find_empty_cells(true)[0]
+	if not item:
+		return
+	
+	var stack_comp = item.get_node("StackableComponent") if item.has_node("StackableComponent") else null
+	
+	if stack_comp:
+		# Tenta empilhar em célula existente do mesmo tipo
+		for cell: InventoryCell in grid.get_children():
+			if cell.item and cell.item.item_name == item.item_name and cell.count < stack_comp.stack_size:
+				cell.count += 1
+				item.queue_free()
+				return
+	
+	# Se não conseguiu empilhar, coloca em célula vazia
+	var empty = find_empty_cells(true)
+	if empty.is_empty():
+		push_warning("Inventory is full!")
+		return
+	var cell = empty[0]
 	cell.set_item(item)
+	cell.count = 1
 
 
 func remove_item() -> Item:
@@ -143,26 +232,88 @@ func remove_item() -> Item:
 	return null
 
 
+## Cancela a seleção e retorna o item para a célula de origem.
 func cancel_selected_item() -> void:
 	if selected_cell:
 		handle_new_selected_cell(null)
 
 
+## Remove o item selecionado do inventário e dropa no node_to_drop.
+func drop_selected_item() -> void:
+	if not selected_cell or not selected_item:
+		return
+	
+	selected_cell.is_selected = false
+	
+	if node_to_drop:
+		selected_item.global_position = node_to_drop.global_position
+	selected_item.show()
+	selected_item.force_stop_follow_mouse()
+	selected_item.top_level = false
+	selected_item.z_index = 0
+	
+	selected_cell = null
+	selected_item = null
+	selected_count = 0
+
+
 func set_selected_cell(value : InventoryCell) -> void:
+	# Devolve item da célula anterior (se houver)
 	if selected_cell:
 		selected_cell.is_selected = false
-		selected_cell.set_item(selected_item)
-		selected_item = null
+		if selected_item:
+			selected_cell.set_item(selected_item)
+			selected_cell.count += selected_count
+			selected_item = null
+		selected_count = 0
+	
 	selected_cell = value
 	if not selected_cell:
 		selected_item = null
 		return
-	if selected_cell.item:
+	
+	# Pega o item da nova célula
+	if not selected_cell.item:
+		selected_item = null
+		return
+	
+	var is_stackable = selected_cell.is_stackable()
+	var cell_count = selected_cell.count
+	
+	# Se for stackável, count > 1 e NÃO segurou Shift → pega só 1 unidade
+	if is_stackable and cell_count > 1 and not Input.is_key_pressed(KEY_SHIFT):
+		selected_count = 1
+		selected_cell.count -= 1
+		selected_item = selected_cell.remove_item_for_stack(self)
+	else:
+		# Pega o stack inteiro
+		selected_count = cell_count
+		selected_cell.count = 0
 		selected_item = selected_cell.remove_item(self)
+	
+	if selected_item:
 		selected_item.top_level = true
 		selected_item.z_index = 100
 		selected_item.force_follow_mouse()
-		pass
+
+
+func _handle_split_stack(cell: InventoryCell, half: int) -> void:
+	if selected_cell or not cell.item:
+		return
+	if half <= 0 or half >= cell.count:
+		return
+	
+	cell.count -= half
+	
+	# Pega o Item da célula e carrega metade do stack
+	selected_item = cell.remove_item_for_stack(self)
+	selected_cell = cell
+	selected_count = half
+	
+	if selected_item:
+		selected_item.top_level = true
+		selected_item.z_index = 100
+		selected_item.force_follow_mouse()
 
 
 func get_selected_pos() -> Vector2i:
@@ -172,8 +323,6 @@ func get_selected_pos() -> Vector2i:
 		selected_pos = Vector2i.MIN
 	return selected_pos
 
-
-# TODO all those functions should be in a InventoryGrid class to modularize.
 
 func get_cell(pos : Vector2i) -> InventoryCell:
 	if pos.x >= dimensions.x or pos.y >= dimensions.y:

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -242,7 +242,10 @@ func handle_wants_item_removed(cell: InventoryCell) -> void:
 	_restore_selected()
 	
 	var item: Item = remove_item_at(get_pos(cell))
+	# Reparenta imediatamente pro mundo (remove_item usa call_deferred)
+	item.reparent(get_tree().current_scene)
 	item.global_position = node_to_drop.global_position
+	_disable_pickup_temporarily(item)
 
 
 func add_item(item: Item) -> void:
@@ -294,20 +297,35 @@ func drop_selected_item() -> void:
 		return
 	
 	selected_cell.is_selected = false
+	var drop_pos := node_to_drop.global_position
 	
 	if selected_cell.item:
-		# Duplicado (pickup parcial / split): tira do stack e dropa no mundo
-		selected_cell.count -= selected_count
+		# Duplicado (pickup parcial / split): dropa no mundo
 		selected_item.reparent(get_tree().current_scene)
-		selected_item.global_position = node_to_drop.global_position
+		selected_item.global_position = drop_pos
 	else:
 		# Item real (pickup total): reposiciona no mundo
-		selected_item.global_position = node_to_drop.global_position
+		selected_item.reparent(get_tree().current_scene)
+		selected_item.global_position = drop_pos
 		selected_item.show()
+	
+	# Se o pickup representa múltiplas unidades (shift+click em stack
+	# ou split), spawna as extras como duplicatas
+	if selected_count > 1:
+		for i in range(selected_count - 1):
+			var extra := selected_item.duplicate()
+			extra.global_position = drop_pos + Vector2.RIGHT * ((i + 1) * 12)
+			get_tree().current_scene.add_child(extra)
+			extra.top_level = false
+			extra.z_index = 0
+			extra.force_stop_follow_mouse()
+			extra.show()
+			_disable_pickup_temporarily(extra)
 	
 	selected_item.force_stop_follow_mouse()
 	selected_item.top_level = false
 	selected_item.z_index = 0
+	_disable_pickup_temporarily(selected_item)
 	_cleanup_selection()
 
 
@@ -315,6 +333,22 @@ func _cleanup_selection() -> void:
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
+
+
+## Desativa o pickup do item dropped por 0.5s pra evitar
+## que o player pegue ele de volta imediatamente (o interactable
+## area sobrepõe o player quando dropa aos pés).
+func _disable_pickup_temporarily(item: Item) -> void:
+	if not item or not item.interactable_area:
+		return
+	item.interactable_area.monitoring = false
+	var timer := get_tree().create_timer(0.5)
+	timer.timeout.connect(_make_dropped_item_pickupable.bind(item), CONNECT_ONE_SHOT)
+
+
+func _make_dropped_item_pickupable(item: Item) -> void:
+	if is_instance_valid(item) and item.interactable_area:
+		item.interactable_area.monitoring = true
 
 
 ## Restaura o item carregado (se houver) para a célula de origem.
@@ -350,10 +384,10 @@ func set_selected_cell(value: InventoryCell) -> void:
 	var is_stackable = selected_cell.is_stackable()
 	var cell_count = selected_cell.count
 	
-	if is_stackable and cell_count > 1 and not Input.is_key_pressed(KEY_SHIFT):
-		# Pickup parcial: duplica o Item, original fica na célula
-		selected_count = 1
-		selected_cell.count -= 1
+	if is_stackable and cell_count > 1:
+		# Stack com mais de 1: sempre duplica, original fica na célula
+		selected_count = cell_count if Input.is_key_pressed(KEY_SHIFT) else 1
+		selected_cell.count -= selected_count
 		selected_item = selected_cell.item.duplicate()
 		add_child(selected_item)
 		selected_item.show()
@@ -361,10 +395,10 @@ func set_selected_cell(value: InventoryCell) -> void:
 		selected_item.z_index = 100
 		selected_item.force_follow_mouse()
 	else:
-		# Pickup total: Item sai da célula e segue o mouse
+		# Não stackável ou count == 1: Item sai da célula
 		selected_count = cell_count
 		selected_cell.count = 0
-		selected_item = selected_cell.remove_item(self)
+		selected_item = selected_cell.remove_item(self, true, true)
 		if selected_item:
 			selected_item.top_level = true
 			selected_item.z_index = 100

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -36,6 +36,20 @@ func _ready() -> void:
 	dimensions = dimensions
 
 
+func _process(_delta: float) -> void:
+	if not Input.is_action_just_released("right_click"):
+		return
+	if not selected_cell or not selected_item:
+		return
+	
+	# Só age se o clique foi FORA do inventário
+	var inside = Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position())
+	if inside:
+		return
+	
+	drop_selected_item()
+
+
 
 func _gui_input(event: InputEvent) -> void:
 	if not event is InputEventMouseButton:
@@ -212,8 +226,11 @@ func remove_empty_cells(max_number: int) -> int:
 
 
 func handle_wants_item_removed(cell: InventoryCell) -> void:
-	if selected_cell or not cell.item:
+	if not cell.item:
 		return
+	
+	# Restaura item carregado primeiro
+	_restore_selected()
 	
 	var item: Item = remove_item_at(get_pos(cell))
 	if node_to_drop:
@@ -288,18 +305,26 @@ func _cleanup_selection() -> void:
 	selected_count = 0
 
 
+## Restaura o item carregado (se houver) para a célula de origem.
+func _restore_selected() -> void:
+	if not selected_cell:
+		return
+	if selected_item:
+		if selected_cell.item:
+			selected_cell.count += selected_count
+			selected_item.queue_free()
+		else:
+			selected_cell.set_item(selected_item)
+			selected_cell.count = selected_count
+	selected_cell = null
+	selected_item = null
+	selected_count = 0
+
+
 func set_selected_cell(value: InventoryCell) -> void:
 	if selected_cell:
 		selected_cell.is_selected = false
-		if selected_item:
-			if selected_cell.item:
-				selected_cell.count += selected_count
-				selected_item.queue_free()
-			else:
-				selected_cell.set_item(selected_item)
-				selected_cell.count = selected_count
-			selected_item = null
-		selected_count = 0
+		_restore_selected()
 	
 	selected_cell = value
 	if not selected_cell:
@@ -335,10 +360,13 @@ func set_selected_cell(value: InventoryCell) -> void:
 
 
 func _handle_split_stack(cell: InventoryCell, half: int) -> void:
-	if selected_cell or not cell.item:
+	if not cell.item:
 		return
 	if half <= 0 or half >= cell.count:
 		return
+	
+	# Restaura item carregado primeiro
+	_restore_selected()
 	
 	# Split: duplica o Item, original fica na célula
 	var new_item = cell.item.duplicate()

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -95,14 +95,14 @@ func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
 			return
 		var space = stack_comp.stack_size - target.count
 		if space > 0:
-			var move = mini(source_count, space)
+			var move = min(source_count, space)
 			target.count += move
 			source_count -= move
 			
 			if source_count <= 0:
-				source.count = 0
+				if source.count <= 0:
+					source.item = null
 				source.is_selected = false
-				source.item = null
 				selected_cell = null
 				selected_item = null
 				selected_count = 0

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -16,6 +16,7 @@ signal cell_left_clicked(cell : InventoryCell)
 @export var node_to_drop : Node2D
 
 @export var can_move_items : bool = true
+@export var can_drop_items : bool = true
 
 
 var selected_cell : InventoryCell
@@ -37,6 +38,8 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
+	if not can_drop_items:
+		return
 	if not Input.is_action_just_released("right_click"):
 		return
 	if not selected_cell or not selected_item:
@@ -226,6 +229,9 @@ func remove_empty_cells(max_number: int) -> int:
 
 func handle_wants_item_removed(cell: InventoryCell) -> void:
 	if not cell.item:
+		return
+	
+	if not can_drop_items:
 		return
 	
 	if not node_to_drop:

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -76,58 +76,61 @@ func handle_cell_left_clicked(cell : InventoryCell) -> void:
 		handle_new_selected_cell(cell)
 
 
-## Troca o item entre selected_cell e a célula do parâmetro,
-## fazendo merge se forem do mesmo tipo stackável.
+## Lida com o drop do item selecionado em uma célula alvo.
+## Três casos: merge (mesmo tipo stackável), mover (vazia), swap (tipo diferente).
 func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
-	var source_item: Item = selected_item
-	var source_count: int = selected_count
-	
-	if not source_item:
-		push_warning("No item to place")
+	if not selected_item:
 		return
 	
-	# Merge: mesmo tipo e stackável e com espaço
-	if target.item and target.item.item_name == source_item.item_name and target.is_stackable():
+	var src_item: Item = selected_item
+	var src_count: int = selected_count
+	
+	# Caso 1: Merge — mesmo tipo, stackável, com espaço
+	if target.item and target.item.item_name == src_item.item_name and target.is_stackable():
 		var stack_comp = target.item.get_node("StackableComponent")
-		if not stack_comp:
-			# Fallback: swap normal
-			_do_swap(source, target, source_item, source_count)
-			return
-		var space = stack_comp.stack_size - target.count
-		if space > 0:
-			var move = min(source_count, space)
-			target.count += move
-			source_count -= move
-			
-			if source_count <= 0:
-				if source.count <= 0:
-					source.item = null
-				source.is_selected = false
-				selected_cell = null
-				selected_item = null
-				selected_count = 0
-				source_item.queue_free()
-				return
-			else:
-				# Ainda sobrou unidade na mão — mantém seleção
-				selected_count = source_count
-				source.is_selected = false
-				return
-		# Sem espaço, cai no swap normal
+		if stack_comp:
+			var space = stack_comp.stack_size - target.count
+			if space > 0:
+				var move = min(src_count, space)
+				target.count += move
+				src_count -= move
+				
+				if src_count <= 0:
+					if source.count <= 0:
+						source.item = null
+					source.is_selected = false
+					selected_cell = null
+					selected_item = null
+					selected_count = 0
+					src_item.queue_free()
+					return
+				else:
+					selected_count = src_count
+					source.is_selected = false
+					return
 	
-	# Swap normal (ou target com tipo diferente)
-	_do_swap(source, target, source_item, source_count)
-
-
-func _do_swap(source: InventoryCell, target: InventoryCell, source_item: Item, source_count: int) -> void:
-	var target_item: Item = target.item
-	var target_count: int = target.count
+	# Caso 2: Célula vazia — move o item
+	if not target.item:
+		target.set_item(src_item)
+		target.count = src_count
+		
+		if source.count <= 0:
+			source.item = null
+		
+		source.is_selected = false
+		selected_cell = null
+		selected_item = null
+		selected_count = 0
+		return
 	
-	target.item = source_item
-	target.count = source_count
+	# Caso 3: Swap — tipos diferentes
+	var tgt_item: Item = target.item
+	var tgt_count: int = target.count
 	
-	source.item = target_item
-	source.count = target_count
+	target.item = src_item
+	target.count = src_count
+	source.item = tgt_item
+	source.count = tgt_count
 	
 	source.is_selected = false
 	target.is_selected = false
@@ -262,8 +265,9 @@ func set_selected_cell(value : InventoryCell) -> void:
 	if selected_cell:
 		selected_cell.is_selected = false
 		if selected_item:
+			var remaining: int = selected_cell.count
 			selected_cell.set_item(selected_item)
-			selected_cell.count += selected_count
+			selected_cell.count = remaining + selected_count
 			selected_item = null
 		selected_count = 0
 	

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -221,14 +221,15 @@ func handle_wants_item_removed(cell: InventoryCell) -> void:
 	if not cell.item:
 		return
 	
+	if not node_to_drop:
+		push_error("No node_to_drop set. Cannot remove item from inventory.")
+		return
+	
 	# Restaura item carregado primeiro
 	_restore_selected()
 	
 	var item: Item = remove_item_at(get_pos(cell))
-	if node_to_drop:
-		item.global_position = node_to_drop.global_position
-	else:
-		push_error("Node where to drop items is not set. Dropped at position zero of ", item.get_parent())
+	item.global_position = node_to_drop.global_position
 
 
 func add_item(item: Item) -> void:

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -319,6 +319,7 @@ func set_selected_cell(value: InventoryCell) -> void:
 		selected_cell.count -= 1
 		selected_item = selected_cell.item.duplicate()
 		add_child(selected_item)
+		selected_item.show()
 		selected_item.top_level = true
 		selected_item.z_index = 100
 		selected_item.force_follow_mouse()
@@ -342,6 +343,7 @@ func _handle_split_stack(cell: InventoryCell, half: int) -> void:
 	# Split: duplica o Item, original fica na célula
 	var new_item = cell.item.duplicate()
 	add_child(new_item)
+	new_item.show()
 	
 	cell.count -= half
 	

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -51,15 +51,7 @@ func _process(_delta: float) -> void:
 
 
 
-func _gui_input(event: InputEvent) -> void:
-	if not event is InputEventMouseButton:
-		return
-	if not selected_cell:
-		return
-	
-	if event.is_action_released("right_click"):
-		if selected_cell:
-			drop_selected_item()
+
 
 
 func set_dimensions(value : Vector2i) -> void:
@@ -243,6 +235,9 @@ func add_item(item: Item) -> void:
 	if not item:
 		return
 	
+	# Se tem item carregado, restaura antes pra não duplicar
+	_restore_selected()
+	
 	var stack_comp = item.get_node("StackableComponent") if item.has_node("StackableComponent") else null
 	
 	if stack_comp:
@@ -281,18 +276,21 @@ func drop_selected_item() -> void:
 	
 	if not node_to_drop:
 		push_error("No node_to_drop set. Cannot drop item.")
-		if selected_cell.item:
-			selected_cell.count += selected_count
-			selected_item.queue_free()
-		else:
-			selected_cell.set_item(selected_item)
-			selected_cell.count = selected_count
-		_cleanup_selection()
+		_restore_selected()
 		return
 	
 	selected_cell.is_selected = false
-	selected_item.global_position = node_to_drop.global_position
-	selected_item.show()
+	
+	if selected_cell.item:
+		# Duplicado (pickup parcial / split): tira do stack e dropa no mundo
+		selected_cell.count -= selected_count
+		selected_item.reparent(get_tree().current_scene)
+		selected_item.global_position = node_to_drop.global_position
+	else:
+		# Item real (pickup total): reposiciona no mundo
+		selected_item.global_position = node_to_drop.global_position
+		selected_item.show()
+	
 	selected_item.force_stop_follow_mouse()
 	selected_item.top_level = false
 	selected_item.z_index = 0

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -242,10 +242,7 @@ func handle_wants_item_removed(cell: InventoryCell) -> void:
 	_restore_selected()
 	
 	var item: Item = remove_item_at(get_pos(cell))
-	# Reparenta imediatamente pro mundo (remove_item usa call_deferred)
-	item.reparent(get_tree().current_scene)
 	item.global_position = node_to_drop.global_position
-	_disable_pickup_temporarily(item)
 
 
 func add_item(item: Item) -> void:
@@ -297,35 +294,20 @@ func drop_selected_item() -> void:
 		return
 	
 	selected_cell.is_selected = false
-	var drop_pos := node_to_drop.global_position
 	
 	if selected_cell.item:
-		# Duplicado (pickup parcial / split): dropa no mundo
+		# Duplicado (pickup parcial / split): tira do stack e dropa no mundo
+		selected_cell.count -= selected_count
 		selected_item.reparent(get_tree().current_scene)
-		selected_item.global_position = drop_pos
+		selected_item.global_position = node_to_drop.global_position
 	else:
 		# Item real (pickup total): reposiciona no mundo
-		selected_item.reparent(get_tree().current_scene)
-		selected_item.global_position = drop_pos
+		selected_item.global_position = node_to_drop.global_position
 		selected_item.show()
-	
-	# Se o pickup representa múltiplas unidades (shift+click em stack
-	# ou split), spawna as extras como duplicatas
-	if selected_count > 1:
-		for i in range(selected_count - 1):
-			var extra := selected_item.duplicate()
-			extra.global_position = drop_pos + Vector2.RIGHT * ((i + 1) * 12)
-			get_tree().current_scene.add_child(extra)
-			extra.top_level = false
-			extra.z_index = 0
-			extra.force_stop_follow_mouse()
-			extra.show()
-			_disable_pickup_temporarily(extra)
 	
 	selected_item.force_stop_follow_mouse()
 	selected_item.top_level = false
 	selected_item.z_index = 0
-	_disable_pickup_temporarily(selected_item)
 	_cleanup_selection()
 
 
@@ -333,22 +315,6 @@ func _cleanup_selection() -> void:
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
-
-
-## Desativa o pickup do item dropped por 0.5s pra evitar
-## que o player pegue ele de volta imediatamente (o interactable
-## area sobrepõe o player quando dropa aos pés).
-func _disable_pickup_temporarily(item: Item) -> void:
-	if not item or not item.interactable_area:
-		return
-	item.interactable_area.monitoring = false
-	var timer := get_tree().create_timer(0.5)
-	timer.timeout.connect(_make_dropped_item_pickupable.bind(item), CONNECT_ONE_SHOT)
-
-
-func _make_dropped_item_pickupable(item: Item) -> void:
-	if is_instance_valid(item) and item.interactable_area:
-		item.interactable_area.monitoring = true
 
 
 ## Restaura o item carregado (se houver) para a célula de origem.
@@ -384,10 +350,10 @@ func set_selected_cell(value: InventoryCell) -> void:
 	var is_stackable = selected_cell.is_stackable()
 	var cell_count = selected_cell.count
 	
-	if is_stackable and cell_count > 1:
-		# Stack com mais de 1: sempre duplica, original fica na célula
-		selected_count = cell_count if Input.is_key_pressed(KEY_SHIFT) else 1
-		selected_cell.count -= selected_count
+	if is_stackable and cell_count > 1 and not Input.is_key_pressed(KEY_SHIFT):
+		# Pickup parcial: duplica o Item, original fica na célula
+		selected_count = 1
+		selected_cell.count -= 1
 		selected_item = selected_cell.item.duplicate()
 		add_child(selected_item)
 		selected_item.show()
@@ -395,10 +361,10 @@ func set_selected_cell(value: InventoryCell) -> void:
 		selected_item.z_index = 100
 		selected_item.force_follow_mouse()
 	else:
-		# Não stackável ou count == 1: Item sai da célula
+		# Pickup total: Item sai da célula e segue o mouse
 		selected_count = cell_count
 		selected_cell.count = 0
-		selected_item = selected_cell.remove_item(self, true, true)
+		selected_item = selected_cell.remove_item(self)
 		if selected_item:
 			selected_item.top_level = true
 			selected_item.z_index = 100

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -242,7 +242,11 @@ func handle_wants_item_removed(cell: InventoryCell) -> void:
 	_restore_selected()
 	
 	var item: Item = remove_item_at(get_pos(cell))
+	# Reparenta pro mundo antes de setar posição (remove_item usa deferred)
+	item.reparent(get_tree().current_scene)
 	item.global_position = node_to_drop.global_position
+	item.dropped_count = 1
+	_disable_pickup_temporarily(item)
 
 
 func add_item(item: Item) -> void:
@@ -252,22 +256,44 @@ func add_item(item: Item) -> void:
 	# Se tem item carregado, restaura antes pra não duplicar
 	_restore_selected()
 	
+	var amount = max(1, item.dropped_count)
+	item.dropped_count = 1  # reseta pro padrão
 	var stack_comp = item.get_node("StackableComponent") if item.has_node("StackableComponent") else null
 	
 	if stack_comp:
+		var stack_size = stack_comp.stack_size
+		# Empilha em células existentes do mesmo tipo
 		for cell: InventoryCell in grid.get_children():
-			if cell.item and cell.item.item_name == item.item_name and cell.count < stack_comp.stack_size:
-				cell.count += 1
+			if not cell.item or cell.item.item_name != item.item_name:
+				continue
+			var space = stack_size - cell.count
+			if space <= 0:
+				continue
+			var move = min(amount, space)
+			cell.count += move
+			amount -= move
+			if amount <= 0:
 				item.queue_free()
 				return
-	
-	var empty = find_empty_cells(true)
-	if empty.is_empty():
-		push_warning("Inventory is full!")
-		return
-	var cell = empty[0]
-	cell.set_item(item)
-	cell.count = 1
+		# Coloca o resto em célula vazia
+		if amount > 0:
+			var empty = find_empty_cells(true)
+			if empty.is_empty():
+				push_warning("Inventory is full!")
+				item.queue_free()
+				return
+			var cell = empty[0]
+			cell.set_item(item)
+			cell.count = amount
+	else:
+		# Não stackável
+		var empty = find_empty_cells(true)
+		if empty.is_empty():
+			push_warning("Inventory is full!")
+			return
+		var cell = empty[0]
+		cell.set_item(item)
+		cell.count = 1
 
 
 func remove_item() -> Item:
@@ -294,20 +320,24 @@ func drop_selected_item() -> void:
 		return
 	
 	selected_cell.is_selected = false
+	var drop_pos := node_to_drop.global_position
 	
 	if selected_cell.item:
-		# Duplicado (pickup parcial / split): tira do stack e dropa no mundo
-		selected_cell.count -= selected_count
+		# Duplicado (pickup parcial / split): dropa no mundo
 		selected_item.reparent(get_tree().current_scene)
-		selected_item.global_position = node_to_drop.global_position
+		selected_item.global_position = drop_pos
 	else:
 		# Item real (pickup total): reposiciona no mundo
-		selected_item.global_position = node_to_drop.global_position
+		selected_item.reparent(get_tree().current_scene)
+		selected_item.global_position = drop_pos
 		selected_item.show()
+	
+	selected_item.dropped_count = selected_count
 	
 	selected_item.force_stop_follow_mouse()
 	selected_item.top_level = false
 	selected_item.z_index = 0
+	_disable_pickup_temporarily(selected_item)
 	_cleanup_selection()
 
 
@@ -315,6 +345,21 @@ func _cleanup_selection() -> void:
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
+
+
+## Desativa o pickup do item dropped por 0.5s pra evitar
+## que o player pegue ele de volta imediatamente.
+func _disable_pickup_temporarily(item: Item) -> void:
+	if not item or not item.interactable_area:
+		return
+	item.interactable_area.monitoring = false
+	var timer := get_tree().create_timer(0.5)
+	timer.timeout.connect(_make_dropped_item_pickupable.bind(item), CONNECT_ONE_SHOT)
+
+
+func _make_dropped_item_pickupable(item: Item) -> void:
+	if is_instance_valid(item) and item.interactable_area:
+		item.interactable_area.monitoring = true
 
 
 ## Restaura o item carregado (se houver) para a célula de origem.
@@ -364,7 +409,7 @@ func set_selected_cell(value: InventoryCell) -> void:
 		# Pickup total: Item sai da célula e segue o mouse
 		selected_count = cell_count
 		selected_cell.count = 0
-		selected_item = selected_cell.remove_item(self)
+		selected_item = selected_cell.remove_item(self, true, true)
 		if selected_item:
 			selected_item.top_level = true
 			selected_item.z_index = 100

--- a/Game-Loot-Lunch/entities/inventory/inventory.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory.gd
@@ -13,22 +13,22 @@ signal cell_left_clicked(cell : InventoryCell)
 @export var dimensions : Vector2i = Vector2i.ONE:
 	set = set_dimensions
 	
-## Representá o nó a ser usado como base para dropar itens.
-## Em geral, uma [Marker2D] seria o melhor mas pode usar algo como o [Player],
-## por exemplo.
 @export var node_to_drop : Node2D
 
 @export var can_move_items : bool = true
 
 
 var selected_cell : InventoryCell
+## Item físico seguindo o mouse (pickup total / split).
+## Fica null quando é pickup parcial (ghost).
 var selected_item : Item
-## Quantas unidades do item estão atualmente selecionadas/seguindo o mouse.
-## Para não-stackáveis ou full-stack, = cell.count original.
-## Para pick-up parcial (1 unidade de um stack), = 1.
+## Quantas unidades estamos carregando.
 var selected_count : int = 0
 var selected_pos : Vector2i:
 	get = get_selected_pos
+
+## Fantasma visual para pickup parcial (quando o Item fica na célula).
+var _ghost: Sprite2D = null
 
 
 @onready var container: PanelContainer = $Container
@@ -37,6 +37,11 @@ var selected_pos : Vector2i:
 
 func _ready() -> void:
 	dimensions = dimensions
+
+
+func _process(_delta: float) -> void:
+	if _ghost:
+		_ghost.global_position = get_global_mouse_position()
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -74,62 +79,53 @@ func handle_cell_left_clicked(cell : InventoryCell) -> void:
 		handle_new_selected_cell(cell)
 
 
-## Lida com o drop do item selecionado em uma célula alvo.
-## Três casos: merge (mesmo tipo stackável), mover (vazia), swap (tipo diferente).
-func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
-	if not selected_item:
-		return
+func _try_merge(source: InventoryCell, target: InventoryCell, src_item: Item, src_count: int) -> bool:
+	if not target.item or target.item.item_name != src_item.item_name or not target.is_stackable():
+		return false
+	var stack_comp = target.item.get_node("StackableComponent")
+	if not stack_comp:
+		return false
+	var space = stack_comp.stack_size - target.count
+	if space <= 0:
+		return false
 	
-	var src_item: Item = selected_item
-	var src_count: int = selected_count
+	var move = min(src_count, space)
+	target.count += move
+	src_count -= move
 	
-	# Caso 1: Merge — mesmo tipo, stackável, com espaço
-	if target.item and target.item.item_name == src_item.item_name and target.is_stackable():
-		var stack_comp = target.item.get_node("StackableComponent")
-		if stack_comp:
-			var space = stack_comp.stack_size - target.count
-			if space > 0:
-				var move = min(src_count, space)
-				target.count += move
-				src_count -= move
-				
-				if src_count <= 0:
-					if source.count <= 0:
-						source.item = null
-					source.is_selected = false
-					selected_cell = null
-					selected_item = null
-					selected_count = 0
-					src_item.queue_free()
-					return
-				else:
-					selected_count = src_count
-					source.is_selected = false
-					return
-	
-	# Caso 2: Célula vazia — move o item
-	if not target.item:
-		target.set_item(src_item)
-		target.count = src_count
-		
+	if src_count <= 0:
 		if source.count <= 0:
 			source.item = null
-		
 		source.is_selected = false
 		selected_cell = null
 		selected_item = null
 		selected_count = 0
-		return
+		src_item.queue_free()
+		_remove_ghost()
+		return true
 	
-	# Caso 3: Swap — tipos diferentes
-	# Se a source ainda tem unidades virtuais (pick-up parcial),
-	# não dá pra fazer swap limpo — retorna o carry pra source.
-	if source.count > 0:
-		set_selected_cell(null)
-		return
+	selected_count = src_count
+	source.is_selected = false
+	return true
+
+
+func _place_on_empty(source: InventoryCell, target: InventoryCell, src_item: Item, src_count: int) -> void:
+	target.set_item(src_item)
+	target.count = src_count
 	
-	var tgt_item: Item = target.item
-	var tgt_count: int = target.count
+	if source.count <= 0:
+		source.item = null
+	
+	source.is_selected = false
+	selected_cell = null
+	selected_item = null
+	selected_count = 0
+	_remove_ghost()
+
+
+func _do_swap(source: InventoryCell, target: InventoryCell, src_item: Item, src_count: int) -> void:
+	var tgt_item = target.item
+	var tgt_count = target.count
 	
 	target.item = src_item
 	target.count = src_count
@@ -143,12 +139,65 @@ func _swap_or_merge(source: InventoryCell, target: InventoryCell) -> void:
 	selected_count = 0
 
 
-## Returns an array with the references of all empty cells
-## [br]
-## if 'first' is true, returns as soon as it finds one
-func find_empty_cells(first : bool = false) -> Array[InventoryCell]:
-	var result : Array[InventoryCell] = []
-	for cell : InventoryCell in grid.get_children():
+func handle_new_selected_cell(cell : InventoryCell) -> void:
+	if not cell:
+		set_selected_cell(null)
+		return
+	
+	if not selected_cell:
+		if not cell.item:
+			cell.is_selected = false
+			return
+		set_selected_cell(cell)
+		return
+	
+	if selected_cell == cell:
+		set_selected_cell(null)
+		return
+	
+	# --- Tem um item/ghost selecionado, clicou em outra célula ---
+	
+	var source = selected_cell
+	var src_count = selected_count
+	var src_item = selected_item
+	
+	# Se for ghost (pickup parcial), o Item ainda está na source
+	if not src_item:
+		src_item = source.item
+	
+	if not src_item:
+		push_warning("Nothing to place")
+		return
+	
+	# Merge: mesmo tipo, stackável, com espaço
+	if _try_merge(source, cell, src_item, src_count):
+		return
+	
+	# Ghost (pickup parcial) só pode merge ou cancelar
+	if not selected_item:
+		# Return to source
+		set_selected_cell(null)
+		return
+	
+	# Com Item físico: célula vazia → move
+	if not cell.item:
+		_place_on_empty(source, cell, src_item, src_count)
+		return
+	
+	# Com Item físico: swap
+	if source.count > 0:
+		# Source tem unidades virtuais — não pode swap limpo
+		set_selected_cell(null)
+		return
+	
+	_do_swap(source, cell, src_item, src_count)
+
+
+## Returns an array with the references of all empty cells.
+## if 'first' is true, returns as soon as it finds one.
+func find_empty_cells(first: bool = false) -> Array[InventoryCell]:
+	var result: Array[InventoryCell] = []
+	for cell: InventoryCell in grid.get_children():
 		if not cell.item and cell.count <= 0:
 			result.append(cell)
 			if first:
@@ -156,14 +205,13 @@ func find_empty_cells(first : bool = false) -> Array[InventoryCell]:
 	return result
 
 
-## returns the amount of empty cells removed.
-func remove_empty_cells(max_number : int) -> int:
+func remove_empty_cells(max_number: int) -> int:
 	if not grid:
 		return 0
 	if max_number <= 0:
 		return 0
 	
-	var empty_cells : Array[InventoryCell] = find_empty_cells()
+	var empty_cells: Array[InventoryCell] = find_empty_cells()
 	if len(empty_cells) < max_number:
 		max_number = len(empty_cells)
 	
@@ -172,58 +220,30 @@ func remove_empty_cells(max_number : int) -> int:
 	return max_number
 
 
-func handle_wants_item_removed(cell : InventoryCell) -> void:
+func handle_wants_item_removed(cell: InventoryCell) -> void:
 	if selected_cell or not cell.item:
 		return
 	
-	var item : Item = remove_item_at(get_pos(cell))
+	var item: Item = remove_item_at(get_pos(cell))
 	if node_to_drop:
 		item.global_position = node_to_drop.global_position
 	else:
-		push_error("Node where to drop items is not set. Dropped at position zero of ",item.get_parent())
+		push_error("Node where to drop items is not set. Dropped at position zero of ", item.get_parent())
 
 
-func handle_new_selected_cell(cell : InventoryCell) -> void:
-	if not cell:
-		# Chamado com null = cancelar/deselect (retorna item pra célula)
-		set_selected_cell(null)
-		return
-	
-	if not selected_cell:
-		# Nada selecionado ainda — tenta selecionar esta célula
-		if not cell.item:
-			cell.is_selected = false
-			return
-		set_selected_cell(cell)
-		return
-	
-	if selected_cell == cell:
-		# Clicou na mesma célula = deselect (retorna o item)
-		set_selected_cell(null)
-		return
-	
-	# Tem um item selecionado e clicou em outra célula
-	_swap_or_merge(selected_cell, cell)
-
-
-## Adiciona um Item ao inventário.
-## Se o item for stackável, tenta empilhar em células existentes
-## do mesmo tipo antes de colocar numa célula vazia.
-func add_item(item : Item) -> void:
+func add_item(item: Item) -> void:
 	if not item:
 		return
 	
 	var stack_comp = item.get_node("StackableComponent") if item.has_node("StackableComponent") else null
 	
 	if stack_comp:
-		# Tenta empilhar em célula existente do mesmo tipo
 		for cell: InventoryCell in grid.get_children():
 			if cell.item and cell.item.item_name == item.item_name and cell.count < stack_comp.stack_size:
 				cell.count += 1
 				item.queue_free()
 				return
 	
-	# Se não conseguiu empilhar, coloca em célula vazia
 	var empty = find_empty_cells(true)
 	if empty.is_empty():
 		push_warning("Inventory is full!")
@@ -239,33 +259,60 @@ func remove_item() -> Item:
 	return null
 
 
-## Cancela a seleção e retorna o item para a célula de origem.
 func cancel_selected_item() -> void:
 	if selected_cell:
 		handle_new_selected_cell(null)
 
 
-## Remove o item selecionado do inventário e dropa no node_to_drop.
 func drop_selected_item() -> void:
-	if not selected_cell or not selected_item:
+	if not selected_cell:
 		return
 	
-	selected_cell.is_selected = false
+	# Ghost (pickup parcial) — só restaura
+	if _ghost:
+		selected_cell.count += selected_count
+		_cleanup_selection()
+		return
 	
-	if node_to_drop:
-		selected_item.global_position = node_to_drop.global_position
-	selected_item.show()
-	selected_item.force_stop_follow_mouse()
-	selected_item.top_level = false
-	selected_item.z_index = 0
-	
+	# Item físico seguindo o mouse — dropa no mundo
+	if selected_item:
+		selected_cell.is_selected = false
+		if node_to_drop:
+			selected_item.global_position = node_to_drop.global_position
+		selected_item.show()
+		selected_item.force_stop_follow_mouse()
+		selected_item.top_level = false
+		selected_item.z_index = 0
+		_cleanup_selection()
+
+
+func _cleanup_selection() -> void:
+	_remove_ghost()
 	selected_cell = null
 	selected_item = null
 	selected_count = 0
 
 
-func set_selected_cell(value : InventoryCell) -> void:
-	# Devolve item da célula anterior (se houver)
+func _create_ghost(source: InventoryCell) -> void:
+	if not source.item:
+		return
+	_ghost = Sprite2D.new()
+	_ghost.texture = source.item.texture
+	_ghost.region_enabled = source.item.region_enabled
+	_ghost.region_rect = source.item.region_rect
+	_ghost.scale = source.item.scale
+	_ghost.top_level = true
+	_ghost.z_index = 100
+	add_child(_ghost)
+
+
+func _remove_ghost() -> void:
+	if _ghost:
+		_ghost.queue_free()
+		_ghost = null
+
+
+func set_selected_cell(value: InventoryCell) -> void:
 	if selected_cell:
 		selected_cell.is_selected = false
 		if selected_item:
@@ -273,6 +320,7 @@ func set_selected_cell(value : InventoryCell) -> void:
 			selected_cell.set_item(selected_item)
 			selected_cell.count = remaining + selected_count
 			selected_item = null
+		_remove_ghost()
 		selected_count = 0
 	
 	selected_cell = value
@@ -280,7 +328,6 @@ func set_selected_cell(value : InventoryCell) -> void:
 		selected_item = null
 		return
 	
-	# Pega o item da nova célula
 	if not selected_cell.item:
 		selected_item = null
 		return
@@ -288,21 +335,21 @@ func set_selected_cell(value : InventoryCell) -> void:
 	var is_stackable = selected_cell.is_stackable()
 	var cell_count = selected_cell.count
 	
-	# Se for stackável, count > 1 e NÃO segurou Shift → pega só 1 unidade
 	if is_stackable and cell_count > 1 and not Input.is_key_pressed(KEY_SHIFT):
+		# Pickup parcial: Item fica na célula, ghost visual segue o mouse
 		selected_count = 1
 		selected_cell.count -= 1
-		selected_item = selected_cell.remove_item_for_stack(self)
+		selected_item = null
+		_create_ghost(selected_cell)
 	else:
-		# Pega o stack inteiro
+		# Pickup total: Item sai da célula e segue o mouse
 		selected_count = cell_count
 		selected_cell.count = 0
 		selected_item = selected_cell.remove_item(self)
-	
-	if selected_item:
-		selected_item.top_level = true
-		selected_item.z_index = 100
-		selected_item.force_follow_mouse()
+		if selected_item:
+			selected_item.top_level = true
+			selected_item.z_index = 100
+			selected_item.force_follow_mouse()
 
 
 func _handle_split_stack(cell: InventoryCell, half: int) -> void:
@@ -313,7 +360,7 @@ func _handle_split_stack(cell: InventoryCell, half: int) -> void:
 	
 	cell.count -= half
 	
-	# Pega o Item da célula e carrega metade do stack
+	# Split pega o Item da célula (metade da stack)
 	selected_item = cell.remove_item_for_stack(self)
 	selected_cell = cell
 	selected_count = half
@@ -332,25 +379,25 @@ func get_selected_pos() -> Vector2i:
 	return selected_pos
 
 
-func get_cell(pos : Vector2i) -> InventoryCell:
+func get_cell(pos: Vector2i) -> InventoryCell:
 	if pos.x >= dimensions.x or pos.y >= dimensions.y:
-		push_error("Position "+str(pos)+" outside of Inventory's dimensions") 
+		push_error("Position " + str(pos) + " outside of Inventory's dimensions")
 		return null
-	return grid.get_child(pos.x*dimensions.y + pos.y)
+	return grid.get_child(pos.x * dimensions.y + pos.y)
 
 
-func get_pos(cell : InventoryCell) -> Vector2i:
-	var pos : int = grid.get_children().find(cell)
+func get_pos(cell: InventoryCell) -> Vector2i:
+	var pos: int = grid.get_children().find(cell)
 	if pos == -1:
 		return Vector2i.MIN
-	return Vector2i(pos/dimensions.x, pos%dimensions.y)
+	return Vector2i(pos / dimensions.x, pos % dimensions.y)
 
 
-func remove_item_at(pos : Vector2i) -> Item:
-	var cell : InventoryCell = get_cell(pos)
+func remove_item_at(pos: Vector2i) -> Item:
+	var cell: InventoryCell = get_cell(pos)
 	if not cell:
 		return null
-	var item : Item = cell.remove_item()
+	var item: Item = cell.remove_item()
 	if not item:
 		push_warning("At pos " + str(pos) + ": ")
 		return null
@@ -358,5 +405,5 @@ func remove_item_at(pos : Vector2i) -> Item:
 
 
 func print_inventory_cells() -> void:
-	for cell : InventoryCell in grid.get_children():
+	for cell: InventoryCell in grid.get_children():
 		print(cell.get_children())

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -50,6 +50,7 @@ func _process(_delta: float) -> void:
 func _gui_input(event: InputEvent) -> void:
 	if event.is_action_released("left_click"):
 		left_clicked.emit(self)
+		accept_event()
 	if event.is_action_released("right_click"):
 		if item and _is_stackable() and count > 1:
 			var half : int = count / 2
@@ -57,6 +58,7 @@ func _gui_input(event: InputEvent) -> void:
 				split_stack.emit(self, half)
 		else:
 			wants_item_removed.emit(self)
+		accept_event()
 
 
 ## Remove o Item Node da célula e limpa o visual (count vira 0).

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -80,22 +80,6 @@ func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
 ## Remove o Item Node da célula mas MANTÉM o visual (textura + count).
 ## Usado quando vc pega 1 unidade de um stack — a célula continua
 ## mostrando o ícone e o número de unidades restantes.
-func remove_item_for_stack(new_parent: Node = null) -> Item:
-	if not new_parent:
-		new_parent = get_tree().current_scene
-	if not item:
-		return null
-	var removed: Item = item
-	item = null
-	removed.reparent(new_parent, false)
-	removed.show()
-	removed.force_stop_follow_mouse()
-	removed.top_level = false
-	removed.z_index = 0
-	removed.position = Vector2.ZERO
-	return removed
-
-
 func is_stackable() -> bool:
 	return _is_stackable()
 

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -63,7 +63,7 @@ func _gui_input(event: InputEvent) -> void:
 
 ## Remove o Item Node da célula e limpa o visual (count vira 0).
 ## Usado para remoção completa (não-stackável ou stack inteiro).
-func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
+func remove_item(new_parent : Node = null, _show : bool = true, _immediate : bool = false) -> Item:
 	if not new_parent:
 		new_parent = get_tree().current_scene
 	if not item:
@@ -71,7 +71,10 @@ func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
 		return null
 	var removed_item : Item = item
 	item = null
-	removed_item.call_deferred("reparent", new_parent)
+	if _immediate:
+		removed_item.reparent(new_parent)
+	else:
+		removed_item.call_deferred("reparent", new_parent)
 	if _show: 
 		removed_item.show()
 	else:

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -21,6 +21,11 @@ var is_selected : bool = false:
 var count : int = 0:
 	set = set_count
 
+## Cache: o Item que estava nesta célula era stackável?
+## Usado quando o Item é removido (pick-up parcial) mas count > 0,
+## pra não perder o label de quantidade.
+var _was_stackable: bool = false
+
 
 @onready var item_place: TextureRect = $Panel/ItemPlace
 @onready var price_label: Label = $Panel/PriceLabel
@@ -96,9 +101,9 @@ func is_stackable() -> bool:
 
 
 func _is_stackable() -> bool:
-	if not item:
-		return false
-	return item.has_node("StackableComponent")
+	if item:
+		return item.has_node("StackableComponent")
+	return _was_stackable and count > 0
 
 
 func set_is_selected(value : bool) -> void:
@@ -111,17 +116,20 @@ func set_item(value : Item) -> Item:
 	var previous_item : Item = item
 	item = value
 	if not item:
+		_was_stackable = false
 		item_place.texture = null
 		set_price_text("")
 		count = 0
 		return null
-	elif not item.region_enabled:
-		item_place.texture = item.texture
 	else:
-		var atlas : AtlasTexture = AtlasTexture.new()
-		atlas.atlas = item.texture
-		atlas.region = item.region_rect
-		item_place.texture = atlas
+		_was_stackable = item.has_node("StackableComponent")
+		if not item.region_enabled:
+			item_place.texture = item.texture
+		else:
+			var atlas : AtlasTexture = AtlasTexture.new()
+			atlas.atlas = item.texture
+			atlas.region = item.region_rect
+			item_place.texture = atlas
 	value.hide()
 	value.force_stop_follow_mouse()
 	value.top_level = false

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -63,7 +63,7 @@ func _gui_input(event: InputEvent) -> void:
 
 ## Remove o Item Node da célula e limpa o visual (count vira 0).
 ## Usado para remoção completa (não-stackável ou stack inteiro).
-func remove_item(new_parent : Node = null, _show : bool = true, _immediate : bool = false) -> Item:
+func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
 	if not new_parent:
 		new_parent = get_tree().current_scene
 	if not item:
@@ -71,10 +71,7 @@ func remove_item(new_parent : Node = null, _show : bool = true, _immediate : boo
 		return null
 	var removed_item : Item = item
 	item = null
-	if _immediate:
-		removed_item.reparent(new_parent)
-	else:
-		removed_item.call_deferred("reparent", new_parent)
+	removed_item.call_deferred("reparent", new_parent)
 	if _show: 
 		removed_item.show()
 	else:

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -5,6 +5,7 @@ class_name InventoryCell
 signal selected(cell : InventoryCell)
 signal wants_item_removed(cell : InventoryCell)
 signal left_clicked(cell : InventoryCell)
+signal split_stack(cell : InventoryCell, half : int)
 
 
 @export var item : Item:
@@ -15,17 +16,23 @@ signal left_clicked(cell : InventoryCell)
 
 var is_selected : bool = false:
 	set = set_is_selected
+## Quantas unidades deste item estão nesta célula.
+## Para itens não-stackáveis, sempre 1.
+var count : int = 1:
+	set = set_count
 
 
 @onready var item_place: TextureRect = $Panel/ItemPlace
 @onready var price_label: Label = $Panel/PriceLabel
+@onready var stack_label: Label = $Panel/StackCount
 
 
 func _ready() -> void:
 	item = item
-	add_theme_stylebox_override("panel",StyleBoxFlat.new())
+	add_theme_stylebox_override("panel", StyleBoxFlat.new())
 	_change_bg_color(background_color)
 	set_price_text("")
+	_update_stack_label()
 
 
 func _process(_delta: float) -> void:
@@ -33,15 +40,22 @@ func _process(_delta: float) -> void:
 		_change_bg_color(selected_color)
 	if not is_selected and _get_bg_color() == selected_color:
 		_change_bg_color(background_color)
-	
+
 
 func _gui_input(event: InputEvent) -> void:
 	if event.is_action_released("left_click"):
 		left_clicked.emit(self)
 	if event.is_action_released("right_click"):
-		wants_item_removed.emit(self)
+		if item and _is_stackable() and count > 1:
+			var half : int = count / 2
+			if half > 0:
+				split_stack.emit(self, half)
+		else:
+			wants_item_removed.emit(self)
 
 
+## Remove o Item Node da célula e limpa o visual (count vira 0).
+## Usado para remoção completa (não-stackável ou stack inteiro).
 func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
 	if not new_parent:
 		new_parent = get_tree().current_scene
@@ -50,12 +64,41 @@ func remove_item(new_parent : Node = null, _show : bool = true) -> Item:
 		return null
 	var removed_item : Item = item
 	item = null
-	removed_item.call_deferred("reparent",new_parent)
+	removed_item.call_deferred("reparent", new_parent)
 	if _show: 
 		removed_item.show()
 	else:
 		removed_item.hide()
 	return removed_item
+
+
+## Remove o Item Node da célula mas MANTÉM o visual (textura + count).
+## Usado quando vc pega 1 unidade de um stack — a célula continua
+## mostrando o ícone e o número de unidades restantes.
+func remove_item_for_stack(new_parent: Node = null) -> Item:
+	if not new_parent:
+		new_parent = get_tree().current_scene
+	if not item:
+		return null
+	var removed: Item = item
+	item = null
+	removed.call_deferred("reparent", new_parent)
+	removed.show()
+	removed.force_stop_follow_mouse()
+	removed.top_level = false
+	removed.z_index = 0
+	removed.position = Vector2.ZERO
+	return removed
+
+
+func is_stackable() -> bool:
+	return _is_stackable()
+
+
+func _is_stackable() -> bool:
+	if not item:
+		return false
+	return item.has_node("StackableComponent")
 
 
 func set_is_selected(value : bool) -> void:
@@ -68,8 +111,10 @@ func set_item(value : Item) -> Item:
 	var previous_item : Item = item
 	item = value
 	if not item:
-		item_place.texture = null
-		set_price_text("")
+		if count <= 0:
+			item_place.texture = null
+			set_price_text("")
+		_update_stack_label()
 		return null
 	elif not item.region_enabled:
 		item_place.texture = item.texture
@@ -84,7 +129,23 @@ func set_item(value : Item) -> Item:
 	value.z_index = 0
 	value.position = Vector2.ZERO
 	value.call_deferred("reparent", self)
+	count = 1
 	return previous_item
+
+
+func set_count(value : int) -> void:
+	count = max(0, value)
+	_update_stack_label()
+
+
+func _update_stack_label() -> void:
+	if not is_inside_tree():
+		return
+	if _is_stackable() and count > 1:
+		stack_label.text = str(count)
+		stack_label.show()
+	else:
+		stack_label.hide()
 
 
 func set_price_text(value : String, color : Color = Color.WHITE) -> void:

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -18,7 +18,7 @@ var is_selected : bool = false:
 	set = set_is_selected
 ## Quantas unidades deste item estão nesta célula.
 ## Para itens não-stackáveis, sempre 1.
-var count : int = 1:
+var count : int = 0:
 	set = set_count
 
 
@@ -111,10 +111,9 @@ func set_item(value : Item) -> Item:
 	var previous_item : Item = item
 	item = value
 	if not item:
-		if count <= 0:
-			item_place.texture = null
-			set_price_text("")
-		_update_stack_label()
+		item_place.texture = null
+		set_price_text("")
+		count = 0
 		return null
 	elif not item.region_enabled:
 		item_place.texture = item.texture

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.gd
@@ -87,7 +87,7 @@ func remove_item_for_stack(new_parent: Node = null) -> Item:
 		return null
 	var removed: Item = item
 	item = null
-	removed.call_deferred("reparent", new_parent)
+	removed.reparent(new_parent, false)
 	removed.show()
 	removed.force_stop_follow_mouse()
 	removed.top_level = false

--- a/Game-Loot-Lunch/entities/inventory/inventory_cell.tscn
+++ b/Game-Loot-Lunch/entities/inventory/inventory_cell.tscn
@@ -14,6 +14,13 @@ outline_size = 2
 outline_color = Color(0, 0, 0, 1)
 shadow_size = 0
 
+[sub_resource type="LabelSettings" id="LabelSettings_72mef"]
+font_size = 8
+font_color = Color(1, 1, 1, 1)
+outline_size = 2
+outline_color = Color(0, 0, 0, 1)
+shadow_size = 0
+
 [node name="InventoryCell" type="PanelContainer" unique_id=1560891636]
 custom_minimum_size = Vector2(34, 34)
 offset_right = 32.0
@@ -59,7 +66,18 @@ offset_left = -24.0
 offset_top = -10.0
 grow_horizontal = 0
 grow_vertical = 0
-theme_override_font_sizes/font_size = 8
+theme_override_font_sizes/font_size = 6
 text = "0"
 label_settings = SubResource("LabelSettings_rwyhr")
 horizontal_alignment = 2
+
+[node name="StackCount" type="Label" parent="Panel" unique_id=1314189393]
+layout_mode = 1
+anchors_preset = 0
+offset_left = 1.0
+offset_top = 22.0
+offset_right = 16.0
+offset_bottom = 31.0
+theme_override_font_sizes/font_size = 6
+label_settings = SubResource("LabelSettings_72mef")
+horizontal_alignment = 0

--- a/Game-Loot-Lunch/entities/items/carne.tscn
+++ b/Game-Loot-Lunch/entities/items/carne.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://cle3p5oy53g7r" path="res://entities/base_classes/item/item.gd" id="1_vr55j"]
 [ext_resource type="Texture2D" uid="uid://xnfegqg2xfdc" path="res://assets/art/entities/items/farming_fishing.png" id="2_ao85l"]
+[ext_resource type="Script" path="res://entities/base_classes/stackable_component.gd" id="3_ti5et"]
 
 [node name="Carne" type="Sprite2D" unique_id=1998340507]
 physics_interpolation_mode = 2
@@ -14,3 +15,7 @@ item_name = "Carne"
 description = "Carne Vermelha"
 is_ingredient = true
 metadata/_custom_type_script = "uid://cle3p5oy53g7r"
+
+[node name="StackableComponent" type="Node" parent="."]
+script = ExtResource("3_ti5et")
+stack_size = 5

--- a/Game-Loot-Lunch/entities/player/player.tscn
+++ b/Game-Loot-Lunch/entities/player/player.tscn
@@ -513,11 +513,12 @@ invencibility_time = 1.0
 
 [node name="InventoryLayer" type="CanvasLayer" parent="." index="0" unique_id=1951839530]
 
-[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof")]
+[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof") node_paths=PackedStringArray("node_to_drop")]
 offset_left = -239.0
 offset_top = -130.0
 offset_right = 241.0
 offset_bottom = 140.0
+node_to_drop = NodePath("../..")
 
 [node name="FiniteStateMachine" parent="." index="1" unique_id=394854071]
 script = ExtResource("3_xf5fp")

--- a/Game-Loot-Lunch/entities/player/player.tscn
+++ b/Game-Loot-Lunch/entities/player/player.tscn
@@ -513,11 +513,12 @@ invencibility_time = 1.0
 
 [node name="InventoryLayer" type="CanvasLayer" parent="." index="0" unique_id=1951839530]
 
-[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof")]
+[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 node_paths=PackedStringArray("node_to_drop") instance=ExtResource("3_yqrof")]
 offset_left = -239.0
 offset_top = -130.0
 offset_right = 241.0
 offset_bottom = 140.0
+node_to_drop = NodePath("../../Marker2D")
 
 [node name="FiniteStateMachine" parent="." index="1" unique_id=394854071]
 script = ExtResource("3_xf5fp")
@@ -588,6 +589,9 @@ stream = ExtResource("13_j3ovn")
 
 [node name="AttackSfx" type="AudioStreamPlayer2D" parent="." index="12" unique_id=1883833456]
 stream = ExtResource("14_afbqv")
+
+[node name="Marker2D" type="Marker2D" parent="." index="13" unique_id=254863332]
+position = Vector2(0, 20)
 
 [connection signal="died" from="." to="." method="_on_died"]
 [connection signal="got_hurt" from="." to="." method="_on_got_hurt"]

--- a/Game-Loot-Lunch/entities/player/player.tscn
+++ b/Game-Loot-Lunch/entities/player/player.tscn
@@ -513,11 +513,12 @@ invencibility_time = 1.0
 
 [node name="InventoryLayer" type="CanvasLayer" parent="." index="0" unique_id=1951839530]
 
-[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof")]
+[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 node_paths=PackedStringArray("node_to_drop") instance=ExtResource("3_yqrof")]
 offset_left = -239.0
 offset_top = -130.0
 offset_right = 241.0
 offset_bottom = 140.0
+node_to_drop = NodePath("../../NodeToDrop")
 
 [node name="FiniteStateMachine" parent="." index="1" unique_id=394854071]
 script = ExtResource("3_xf5fp")
@@ -588,6 +589,9 @@ stream = ExtResource("13_j3ovn")
 
 [node name="AttackSfx" type="AudioStreamPlayer2D" parent="." index="12" unique_id=1883833456]
 stream = ExtResource("14_afbqv")
+
+[node name="NodeToDrop" type="Marker2D" parent="." index="13" unique_id=415174180]
+position = Vector2(0, 20)
 
 [connection signal="died" from="." to="." method="_on_died"]
 [connection signal="got_hurt" from="." to="." method="_on_got_hurt"]

--- a/Game-Loot-Lunch/entities/player/player.tscn
+++ b/Game-Loot-Lunch/entities/player/player.tscn
@@ -513,12 +513,11 @@ invencibility_time = 1.0
 
 [node name="InventoryLayer" type="CanvasLayer" parent="." index="0" unique_id=1951839530]
 
-[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 node_paths=PackedStringArray("node_to_drop") instance=ExtResource("3_yqrof")]
+[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof")]
 offset_left = -239.0
 offset_top = -130.0
 offset_right = 241.0
 offset_bottom = 140.0
-node_to_drop = NodePath("../../NodeToDrop")
 
 [node name="FiniteStateMachine" parent="." index="1" unique_id=394854071]
 script = ExtResource("3_xf5fp")
@@ -589,9 +588,6 @@ stream = ExtResource("13_j3ovn")
 
 [node name="AttackSfx" type="AudioStreamPlayer2D" parent="." index="12" unique_id=1883833456]
 stream = ExtResource("14_afbqv")
-
-[node name="NodeToDrop" type="Marker2D" parent="." index="13" unique_id=415174180]
-position = Vector2(0, 20)
 
 [connection signal="died" from="." to="." method="_on_died"]
 [connection signal="got_hurt" from="." to="." method="_on_got_hurt"]

--- a/Game-Loot-Lunch/entities/player/player.tscn
+++ b/Game-Loot-Lunch/entities/player/player.tscn
@@ -513,12 +513,11 @@ invencibility_time = 1.0
 
 [node name="InventoryLayer" type="CanvasLayer" parent="." index="0" unique_id=1951839530]
 
-[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof") node_paths=PackedStringArray("node_to_drop")]
+[node name="Inventory" parent="InventoryLayer" index="0" unique_id=1443629152 instance=ExtResource("3_yqrof")]
 offset_left = -239.0
 offset_top = -130.0
 offset_right = 241.0
 offset_bottom = 140.0
-node_to_drop = NodePath("../..")
 
 [node name="FiniteStateMachine" parent="." index="1" unique_id=394854071]
 script = ExtResource("3_xf5fp")

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
@@ -52,15 +52,17 @@ func open_shop(shop: ShopComponent, inventory: Inventory) -> void:
 	fill_shop_inventory()
 	clear_transfer()
 
-	for cell: InventoryCell in player_inventory.grid.get_children():
-		if cell.split_stack.is_connected(player_inventory._handle_split_stack):
-			cell.split_stack.disconnect(player_inventory._handle_split_stack)
-		if not cell.split_stack.is_connected(_on_player_cell_split_stack):
-			cell.split_stack.connect(_on_player_cell_split_stack)
-		if cell.wants_item_removed.is_connected(player_inventory.handle_wants_item_removed):
-			cell.wants_item_removed.disconnect(player_inventory.handle_wants_item_removed)
-		if not cell.wants_item_removed.is_connected(_on_player_cell_wants_remove):
-			cell.wants_item_removed.connect(_on_player_cell_wants_remove)
+	for inv: Inventory in [player_inventory, shop_inventory, transfer_inventory]:
+		for cell: InventoryCell in inv.grid.get_children():
+			if cell.split_stack.is_connected(inv._handle_split_stack):
+				cell.split_stack.disconnect(inv._handle_split_stack)
+			if cell.wants_item_removed.is_connected(inv.handle_wants_item_removed):
+				cell.wants_item_removed.disconnect(inv.handle_wants_item_removed)
+			if inv == player_inventory:
+				if not cell.split_stack.is_connected(_on_player_cell_split_stack):
+					cell.split_stack.connect(_on_player_cell_split_stack)
+				if not cell.wants_item_removed.is_connected(_on_player_cell_wants_remove):
+					cell.wants_item_removed.connect(_on_player_cell_wants_remove)
 
 	shop_opened.emit()
 
@@ -320,6 +322,10 @@ func add_player_item_to_transfer(cell: InventoryCell, amount: int = 1) -> void:
 	else:
 		var item_to_sell: Item = cell.remove_item()
 		transfer_inventory.add_item(item_to_sell)
+		for c: InventoryCell in transfer_inventory.grid.get_children():
+			if c.item == item_to_sell:
+				c.count = sell_amount
+				break
 		sell_items[item_to_sell] = real_item
 		transfer_item_prices[item_to_sell] = price
 		set_item_price_text(transfer_inventory, item_to_sell, price * sell_amount, Color.RED)

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
@@ -51,6 +51,17 @@ func open_shop(shop: ShopComponent, inventory: Inventory) -> void:
 	fill_player_inventory()
 	fill_shop_inventory()
 	clear_transfer()
+
+	for cell: InventoryCell in player_inventory.grid.get_children():
+		if cell.split_stack.is_connected(player_inventory._handle_split_stack):
+			cell.split_stack.disconnect(player_inventory._handle_split_stack)
+		if not cell.split_stack.is_connected(_on_player_cell_split_stack):
+			cell.split_stack.connect(_on_player_cell_split_stack)
+		if cell.wants_item_removed.is_connected(player_inventory.handle_wants_item_removed):
+			cell.wants_item_removed.disconnect(player_inventory.handle_wants_item_removed)
+		if not cell.wants_item_removed.is_connected(_on_player_cell_wants_remove):
+			cell.wants_item_removed.connect(_on_player_cell_wants_remove)
+
 	shop_opened.emit()
 
 func close_shop() -> void:
@@ -184,7 +195,16 @@ func _on_player_inventory_cell_left_clicked(cell: InventoryCell) -> void:
 	if not cell.item:
 		return
 
-	add_player_item_to_transfer(cell)
+	var shift = Input.is_key_pressed(KEY_SHIFT)
+	add_player_item_to_transfer(cell, cell.count if shift else 1)
+
+
+func _on_player_cell_split_stack(cell: InventoryCell, half: int) -> void:
+	add_player_item_to_transfer(cell, half)
+
+
+func _on_player_cell_wants_remove(cell: InventoryCell) -> void:
+	add_player_item_to_transfer(cell, cell.count)
 
 
 func find_item_scene_by_item(item: Item) -> PackedScene:
@@ -255,7 +275,7 @@ func add_shop_item_to_transfer(item: Item) -> void:
 	update_total_message()
 
 
-func add_player_item_to_transfer(cell: InventoryCell) -> void:
+func add_player_item_to_transfer(cell: InventoryCell, amount: int = 1) -> void:
 	if mode == ShopMode.BUY:
 		message_label.text = "Finalize ou saia da compra atual"
 		return
@@ -265,26 +285,46 @@ func add_player_item_to_transfer(cell: InventoryCell) -> void:
 	if player_inventory.selected_item:
 		player_inventory.cancel_selected_item()
 
-	var visual_item: Item = cell.item
-	var real_item: Item = player_item_copies.get(visual_item)
-
+	var real_item: Item = player_item_copies.get(cell.item)
 	if not real_item:
 		message_label.text = "Item não encontrado no inventário"
 		return
 
-	var price: int = current_shop.get_price_from_item(real_item)
+	var price: int = get_sell_price(real_item)
 	if price < 0:
 		message_label.text = "A loja não compra esse item"
 		return
-	price = get_sell_price(real_item)
 
-	var item_to_sell: Item = cell.remove_item()
-	transfer_inventory.add_item(item_to_sell)
+	var sell_amount: int = mini(amount, cell.count)
+	if sell_amount <= 0:
+		return
 
-	sell_items[item_to_sell] = real_item
-	transfer_item_prices[item_to_sell] = price
-	set_item_price_text(transfer_inventory, item_to_sell, price, Color.RED)
-	total_price += price
+	var is_stackable := cell.is_stackable()
+
+	if is_stackable and cell.count > sell_amount:
+		cell.count -= sell_amount
+		var sell_item: Item = create_item_copy(cell.item)
+		if not sell_item:
+			cell.count += sell_amount
+			return
+		sell_item.hide()
+		add_child(sell_item)
+		transfer_inventory.add_item(sell_item)
+		for c: InventoryCell in transfer_inventory.grid.get_children():
+			if c.item == sell_item:
+				c.count = sell_amount
+				break
+		sell_items[sell_item] = real_item
+		transfer_item_prices[sell_item] = price
+		set_item_price_text(transfer_inventory, sell_item, price * sell_amount, Color.RED)
+	else:
+		var item_to_sell: Item = cell.remove_item()
+		transfer_inventory.add_item(item_to_sell)
+		sell_items[item_to_sell] = real_item
+		transfer_item_prices[item_to_sell] = price
+		set_item_price_text(transfer_inventory, item_to_sell, price * sell_amount, Color.RED)
+
+	total_price += price * sell_amount
 	update_total_message()
 
 
@@ -300,7 +340,15 @@ func clear_transfer() -> void:
 func remove_real_player_item(item_to_remove: Item) -> void:
 	for cell: InventoryCell in real_player_inventory.grid.get_children():
 		if cell.item == item_to_remove:
-			cell.remove_item().queue_free()
+			if cell.is_stackable() and cell.count > 1:
+				cell.count -= 1
+			else:
+				cell.remove_item().queue_free()
+			return
+
+	for cell: InventoryCell in real_player_inventory.grid.get_children():
+		if cell.item and cell.item.item_name == item_to_remove.item_name and cell.is_stackable() and cell.count > 1:
+			cell.count -= 1
 			return
 
 
@@ -394,17 +442,30 @@ func undo_buy_item(cell: InventoryCell) -> void:
 
 
 func undo_sell_item(cell: InventoryCell) -> void:
-	var item: Item = cell.remove_item()
+	var item: Item = cell.item
+	var count: int = cell.count
 	var real_item: Item = sell_items.get(item)
 
 	total_price -= transfer_item_prices.get(item, 0)
 	transfer_item_prices.erase(item)
 	sell_items.erase(item)
 
-	player_inventory.add_item(item)
-	if real_item:
-		player_item_copies[item] = real_item
-		set_item_price_text(player_inventory, item, get_sell_price(real_item), Color.RED)
+	item.reparent(self)
+	item.hide()
+	item.top_level = false
+	item.z_index = 0
+	item.position = Vector2.ZERO
+	cell.item = null
+	cell.count = 0
+
+	var empty: Array[InventoryCell] = player_inventory.find_empty_cells(true)
+	if not empty.is_empty():
+		var target: InventoryCell = empty[0]
+		target.set_item(item)
+		target.count = count
+		if real_item:
+			player_item_copies[item] = real_item
+			set_item_price_text(player_inventory, item, get_sell_price(real_item), Color.RED)
 
 	update_mode_after_undo()
 

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
@@ -79,7 +79,6 @@ func fill_shop_inventory() -> void:
 		
 	for item_scene: PackedScene in current_shop.get_item_scenes():
 		var item: Item = current_shop.create_item(item_scene)
-		call_deferred("add_child",item)
 		shop_inventory.add_item(item)
 		set_item_price_text(shop_inventory, item, current_shop.get_price(item_scene), Color.GREEN)
 
@@ -95,7 +94,6 @@ func fill_player_inventory() -> void:
 		if cell.item:
 			var item_copy: Item = create_item_copy(cell.item)
 			if item_copy:
-				call_deferred("add_child",item_copy)
 				player_inventory.add_item(item_copy)
 				player_item_copies[item_copy] = cell.item
 				set_item_price_text(player_inventory, item_copy, get_sell_price(cell.item), Color.RED)
@@ -136,8 +134,13 @@ func confirm_buy() -> void:
 
 	for cell: InventoryCell in transfer_inventory.grid.get_children():
 		if cell.item:
-			var item: Item = cell.remove_item()
-			real_player_inventory.add_item(item)
+			var item: Item = cell.item
+			var count: int = cell.count
+			for i in count:
+				var unit: Item = item if i == 0 else item.duplicate()
+				real_player_inventory.add_item(unit)
+			cell.item = null
+			cell.count = 0
 
 	clear_transfer()
 	fill_player_inventory()
@@ -211,16 +214,33 @@ func add_shop_item_to_transfer(item: Item) -> void:
 	if total_price + price > PlayerWallet.gold:
 		message_label.text = "Gold insuficiente"
 		return
-	
-	if not can_add_buy_item():
-		message_label.text = "Inventário cheio"
-		return
 
 	var new_item: Item = current_shop.create_item(item_scene)
 	add_child(new_item)
-	transfer_inventory.add_item(new_item)
-	transfer_item_prices[new_item] = price
-	set_item_price_text(transfer_inventory, new_item, price, Color.GREEN)
+
+	if not can_add_buy_item(new_item):
+		message_label.text = "Inventário cheio"
+		new_item.queue_free()
+		return
+
+	var is_stackable = new_item.has_node("StackableComponent")
+	var stacked_in_transfer = false
+
+	if is_stackable:
+		var stack_comp = new_item.get_node("StackableComponent") as StackableComponent
+		for cell: InventoryCell in transfer_inventory.grid.get_children():
+			if cell.item and cell.item.item_name == new_item.item_name and cell.count < stack_comp.stack_size:
+				cell.count += 1
+				stacked_in_transfer = true
+				set_item_price_text(transfer_inventory, cell.item, price * cell.count, Color.GREEN)
+				break
+
+	if not stacked_in_transfer:
+		transfer_inventory.add_item(new_item)
+		transfer_item_prices[new_item] = price
+		set_item_price_text(transfer_inventory, new_item, price, Color.GREEN)
+	else:
+		new_item.queue_free()
 
 	total_price += price
 	update_total_message()
@@ -283,10 +303,24 @@ func _on_transfer_inventory_cell_left_clicked(cell: InventoryCell) -> void:
 
 
 func undo_buy_item(cell: InventoryCell) -> void:
-	var item: Item = cell.remove_item()
-	total_price -= transfer_item_prices.get(item, 0)
-	transfer_item_prices.erase(item)
-	item.queue_free()
+	var item: Item = cell.item
+	if not item:
+		return
+
+	var per_unit_price: int = transfer_item_prices.get(item, 0)
+	if per_unit_price <= 0:
+		return
+
+	if cell.is_stackable() and cell.count > 1:
+		cell.count -= 1
+		total_price -= per_unit_price
+		set_item_price_text(transfer_inventory, item, per_unit_price * cell.count, Color.GREEN)
+	else:
+		cell.remove_item()
+		total_price -= per_unit_price
+		transfer_item_prices.erase(item)
+		item.queue_free()
+
 	update_mode_after_undo()
 
 
@@ -367,8 +401,27 @@ func count_empty_cells(inventory: Inventory) -> int:
 	return total
 
 
-func can_add_buy_item() -> bool:
+func can_add_buy_item(item_to_buy: Item = null) -> bool:
 	var empty_cells: int = count_empty_cells(real_player_inventory)
 	var transfer_items: int = count_items(transfer_inventory)
 
-	return transfer_items + 1 <= empty_cells
+	if transfer_items + 1 <= empty_cells:
+		return true
+
+	if not item_to_buy or not item_to_buy.has_node("StackableComponent"):
+		return false
+
+	var item_name: String = item_to_buy.item_name
+
+	var available_stack_space: int = 0
+	for cell: InventoryCell in real_player_inventory.grid.get_children():
+		if cell.item and cell.item.item_name == item_name and cell.is_stackable():
+			var stack_comp = cell.item.get_node("StackableComponent") as StackableComponent
+			available_stack_space += stack_comp.stack_size - cell.count
+
+	var units_in_transfer: int = 0
+	for cell: InventoryCell in transfer_inventory.grid.get_children():
+		if cell.item and cell.item.item_name == item_name:
+			units_in_transfer += cell.count
+
+	return units_in_transfer < available_stack_space

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.gd
@@ -94,9 +94,15 @@ func fill_player_inventory() -> void:
 		if cell.item:
 			var item_copy: Item = create_item_copy(cell.item)
 			if item_copy:
-				player_inventory.add_item(item_copy)
-				player_item_copies[item_copy] = cell.item
-				set_item_price_text(player_inventory, item_copy, get_sell_price(cell.item), Color.RED)
+				item_copy.hide()
+				add_child(item_copy)
+				var empty: Array[InventoryCell] = player_inventory.find_empty_cells(true)
+				if not empty.is_empty():
+					var target: InventoryCell = empty[0]
+					target.set_item(item_copy)
+					target.count = cell.count
+					player_item_copies[item_copy] = cell.item
+					set_item_price_text(player_inventory, item_copy, get_sell_price(cell.item), Color.RED)
 
 
 func start_buy_mode() -> void:
@@ -215,13 +221,16 @@ func add_shop_item_to_transfer(item: Item) -> void:
 		message_label.text = "Gold insuficiente"
 		return
 
+	if not can_add_buy_item(item):
+		message_label.text = "Inventário cheio"
+		return
+
+	if not can_add_to_transfer(item):
+		message_label.text = "Transferência cheia"
+		return
+
 	var new_item: Item = current_shop.create_item(item_scene)
 	add_child(new_item)
-
-	if not can_add_buy_item(new_item):
-		message_label.text = "Inventário cheio"
-		new_item.queue_free()
-		return
 
 	var is_stackable = new_item.has_node("StackableComponent")
 	var stacked_in_transfer = false
@@ -252,6 +261,9 @@ func add_player_item_to_transfer(cell: InventoryCell) -> void:
 		return
 	if mode == ShopMode.NONE:
 		start_sell_mode()
+
+	if player_inventory.selected_item:
+		player_inventory.cancel_selected_item()
 
 	var visual_item: Item = cell.item
 	var real_item: Item = player_item_copies.get(visual_item)
@@ -293,6 +305,10 @@ func remove_real_player_item(item_to_remove: Item) -> void:
 
 
 func _on_transfer_inventory_cell_left_clicked(cell: InventoryCell) -> void:
+	if player_inventory.selected_item:
+		accept_split_for_sell()
+		return
+
 	if not cell.item:
 		return
 
@@ -300,6 +316,59 @@ func _on_transfer_inventory_cell_left_clicked(cell: InventoryCell) -> void:
 		undo_buy_item(cell)
 	elif mode == ShopMode.SELL:
 		undo_sell_item(cell)
+
+
+func accept_split_for_sell() -> void:
+	if mode == ShopMode.BUY:
+		message_label.text = "Finalize ou saia da compra atual"
+		player_inventory._restore_selected()
+		return
+
+	var source: InventoryCell = player_inventory.selected_cell
+	var selected: Item = player_inventory.selected_item
+	var count: int = player_inventory.selected_count
+
+	if not source or not selected:
+		return
+
+	if mode == ShopMode.NONE:
+		start_sell_mode()
+
+	var real_item: Item = player_item_copies.get(selected)
+	if not real_item and source.item:
+		real_item = player_item_copies.get(source.item)
+
+	if not real_item:
+		player_inventory._cleanup_selection()
+		message_label.text = "Item não encontrado no inventário"
+		return
+
+	var price: int = get_sell_price(real_item)
+	if price < 0:
+		player_inventory._cleanup_selection()
+		message_label.text = "A loja não compra esse item"
+		return
+
+	selected.reparent(self)
+	selected.hide()
+	selected.top_level = false
+	selected.z_index = 0
+	selected.position = Vector2.ZERO
+
+	transfer_inventory.add_item(selected)
+
+	for c: InventoryCell in transfer_inventory.grid.get_children():
+		if c.item == selected:
+			c.count = count
+			break
+
+	sell_items[selected] = real_item
+	transfer_item_prices[selected] = price
+	set_item_price_text(transfer_inventory, selected, price * count, Color.RED)
+	total_price += price * count
+	update_total_message()
+
+	player_inventory._cleanup_selection()
 
 
 func undo_buy_item(cell: InventoryCell) -> void:
@@ -425,3 +494,18 @@ func can_add_buy_item(item_to_buy: Item = null) -> bool:
 			units_in_transfer += cell.count
 
 	return units_in_transfer < available_stack_space
+
+
+func can_add_to_transfer(item_to_check: Item) -> bool:
+	if count_empty_cells(transfer_inventory) > 0:
+		return true
+
+	if not item_to_check.has_node("StackableComponent"):
+		return false
+
+	var stack_comp = item_to_check.get_node("StackableComponent") as StackableComponent
+	for cell: InventoryCell in transfer_inventory.grid.get_children():
+		if cell.item and cell.item.item_name == item_to_check.item_name and cell.count < stack_comp.stack_size:
+			return true
+
+	return false

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.tscn
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.tscn
@@ -80,7 +80,8 @@ horizontal_alignment = 1
 custom_minimum_size = Vector2(110, 138)
 layout_mode = 2
 size_flags_horizontal = 4
-can_move_items = false
+can_move_items = true
+can_drop_items = false
 
 [node name="TransferBox" type="VBoxContainer" parent="Panel/VBoxContainer/Inventories" unique_id=618513615]
 layout_mode = 2
@@ -98,6 +99,7 @@ layout_mode = 2
 size_flags_horizontal = 4
 dimensions = Vector2i(3, 2)
 can_move_items = false
+can_drop_items = false
 
 [node name="ShopBox" type="VBoxContainer" parent="Panel/VBoxContainer/Inventories" unique_id=1482637626]
 layout_mode = 2
@@ -114,6 +116,7 @@ custom_minimum_size = Vector2(110, 138)
 layout_mode = 2
 size_flags_horizontal = 4
 can_move_items = false
+can_drop_items = false
 
 [connection signal="pressed" from="Panel/VBoxContainer/Buttons/BuyButton" to="." method="_on_buy_button_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/Buttons/SellButton" to="." method="_on_sell_button_pressed"]

--- a/Game-Loot-Lunch/systems/shop_menu/shop_menu.tscn
+++ b/Game-Loot-Lunch/systems/shop_menu/shop_menu.tscn
@@ -80,7 +80,7 @@ horizontal_alignment = 1
 custom_minimum_size = Vector2(110, 138)
 layout_mode = 2
 size_flags_horizontal = 4
-can_move_items = true
+can_move_items = false
 can_drop_items = false
 
 [node name="TransferBox" type="VBoxContainer" parent="Panel/VBoxContainer/Inventories" unique_id=618513615]

--- a/Game-Loot-Lunch/tests/inventory/test_inventory.gd
+++ b/Game-Loot-Lunch/tests/inventory/test_inventory.gd
@@ -3,8 +3,12 @@ extends Node2D
 
 @onready var inventory: Inventory = $CanvasLayer/Inventory
 @onready var carne: Item = $Carne
+@onready var carne2: Item = $Carne2
+@onready var carne3: Item = $Carne3
+@onready var carne4: Item = $Carne4
+@onready var carne5: Item = $Carne5
+@onready var carne6: Item = $Carne6
 @onready var tomate: Item = $Tomate
-@onready var farinha: Item = $Farinha 
 @onready var selected_cell: Label = $VBoxContainer/SelectedCell
 @onready var selected_item: Label = $VBoxContainer/SelectedItem
 @onready var selected_pos: Label = $VBoxContainer/SelectedPos
@@ -14,23 +18,21 @@ extends Node2D
 func _ready() -> void:
 	tutorial.text = '''
 	  Press    I    to    show/hide    Inventory
-	  Left    click    to    select/move    items
-	  Right    click    to    cancel    selection/remove    items'''
-					
-	carne.connect("picked_up",inventory.add_item)
-	tomate.connect("picked_up",inventory.add_item)
-	farinha.connect("picked_up",inventory.add_item)
-	'''inventory.add_item(carne)
+	  Left    click    (stack)    to    pick    1  unit
+	  Shift+click    (stack)    to    pick    all
+	  Right    click    (stack)    to    split
+	  Right    click    (bg)    to    drop    item'''
+
+	# Adiciona 6 Carnes e 1 Tomate automaticamente
+	# As primeiras 5 carnes empilham na mesma célula (stack_size=5)
+	# A 6ª vai pra outra célula; o Tomate vai pra uma terceira.
+	inventory.add_item(carne)
+	inventory.add_item(carne2)
+	inventory.add_item(carne3)
+	inventory.add_item(carne4)
+	inventory.add_item(carne5)
+	inventory.add_item(carne6)
 	inventory.add_item(tomate)
-	inventory.add_item(farinha)
-	print("root:\n",get_children(),"\n-----------")
-	print("grid:")
-	inventory.print_inventory_cells()
-	print("\n-----------")
-	await get_tree().create_timer(5).timeout
-	inventory.remove_item_at(Vector2i.RIGHT).force_follow_mouse()
-	print(get_children())
-	inventory.print_inventory_cells()'''
 
 
 func _physics_process(_delta: float) -> void:

--- a/Game-Loot-Lunch/tests/inventory/test_inventory.gd
+++ b/Game-Loot-Lunch/tests/inventory/test_inventory.gd
@@ -1,7 +1,8 @@
 extends Node2D
 
 
-@onready var inventory: Inventory = $CanvasLayer/Inventory
+@onready var inventory_component: InventoryComponent = $Player/InventoryComponent
+@onready var inventory: Inventory = $Player/InventoryLayer/Inventory
 @onready var carne: Item = $Carne
 @onready var carne2: Item = $Carne2
 @onready var carne3: Item = $Carne3
@@ -18,21 +19,15 @@ extends Node2D
 func _ready() -> void:
 	tutorial.text = '''
 	  Press    I    to    show/hide    Inventory
+	  Walk    over    items    to    collect    them
 	  Left    click    (stack)    to    pick    1  unit
 	  Shift+click    (stack)    to    pick    all
 	  Right    click    (stack)    to    split
 	  Right    click    (bg)    to    drop    item'''
 
-	# Adiciona 6 Carnes e 1 Tomate automaticamente
-	# As primeiras 5 carnes empilham na mesma célula (stack_size=5)
-	# A 6ª vai pra outra célula; o Tomate vai pra uma terceira.
-	inventory.add_item(carne)
-	inventory.add_item(carne2)
-	inventory.add_item(carne3)
-	inventory.add_item(carne4)
-	inventory.add_item(carne5)
-	inventory.add_item(carne6)
-	inventory.add_item(tomate)
+	# Conecta o pickup de cada item ao inventário do jogador
+	for item_node: Item in [carne, carne2, carne3, carne4, carne5, carne6, tomate]:
+		item_node.picked_up.connect(inventory_component.add_item)
 
 
 func _physics_process(_delta: float) -> void:
@@ -45,7 +40,8 @@ func _physics_process(_delta: float) -> void:
 
 func _input(_event: InputEvent) -> void:
 	if Input.is_action_just_released("open_inventory"):
-		inventory.visible = not inventory.visible
+		# O InventoryComponent do player já alterna o inventário dele
+		pass
 
 func get_selected_position() -> Array[Vector2i]:
 	var result : Array[Vector2i] = []

--- a/Game-Loot-Lunch/tests/inventory/test_inventory.tscn
+++ b/Game-Loot-Lunch/tests/inventory/test_inventory.tscn
@@ -4,7 +4,6 @@
 [ext_resource type="PackedScene" uid="uid://cqnchp7q3uixs" path="res://entities/inventory/inventory.tscn" id="2_i0jss"]
 [ext_resource type="PackedScene" uid="uid://cexct4fg71pc5" path="res://entities/items/carne.tscn" id="3_2ff5v"]
 [ext_resource type="PackedScene" uid="uid://dwlepdjd5lv8x" path="res://entities/items/tomate.tscn" id="4_67sjd"]
-[ext_resource type="PackedScene" uid="uid://dd8vbsbs33ii4" path="res://entities/items/farinha.tscn" id="5_7tixs"]
 [ext_resource type="FontFile" uid="uid://cvuth304y1byc" path="res://assets/fonts/tinypixel.ttf" id="6_7tixs"]
 [ext_resource type="PackedScene" uid="uid://3cgeew2m05mn" path="res://entities/player/player.tscn" id="6_67sjd"]
 
@@ -30,13 +29,25 @@ dimensions = Vector2i(3, 3)
 node_to_drop = NodePath("../../Droper")
 
 [node name="Carne" parent="." unique_id=1998340507 instance=ExtResource("3_2ff5v")]
-position = Vector2(224.00002, 134)
+position = Vector2(224, 120)
+
+[node name="Carne2" parent="." unique_id=1998340508 instance=ExtResource("3_2ff5v")]
+position = Vector2(256, 120)
+
+[node name="Carne3" parent="." unique_id=1998340509 instance=ExtResource("3_2ff5v")]
+position = Vector2(288, 120)
+
+[node name="Carne4" parent="." unique_id=1998340510 instance=ExtResource("3_2ff5v")]
+position = Vector2(224, 152)
+
+[node name="Carne5" parent="." unique_id=1998340511 instance=ExtResource("3_2ff5v")]
+position = Vector2(256, 152)
+
+[node name="Carne6" parent="." unique_id=1998340512 instance=ExtResource("3_2ff5v")]
+position = Vector2(288, 152)
 
 [node name="Tomate" parent="." unique_id=1065823031 instance=ExtResource("4_67sjd")]
-position = Vector2(302, 135)
-
-[node name="Farinha" parent="." unique_id=546262662 instance=ExtResource("5_7tixs")]
-position = Vector2(270, 181)
+position = Vector2(256, 184)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1047629312]
 offset_right = 40.0

--- a/Game-Loot-Lunch/tests/inventory/test_inventory.tscn
+++ b/Game-Loot-Lunch/tests/inventory/test_inventory.tscn
@@ -1,7 +1,6 @@
 [gd_scene format=3 uid="uid://b7rvih4e4hkcu"]
 
 [ext_resource type="Script" uid="uid://bk8rxeu74ypfd" path="res://tests/inventory/test_inventory.gd" id="1_372ms"]
-[ext_resource type="PackedScene" uid="uid://cqnchp7q3uixs" path="res://entities/inventory/inventory.tscn" id="2_i0jss"]
 [ext_resource type="PackedScene" uid="uid://cexct4fg71pc5" path="res://entities/items/carne.tscn" id="3_2ff5v"]
 [ext_resource type="PackedScene" uid="uid://dwlepdjd5lv8x" path="res://entities/items/tomate.tscn" id="4_67sjd"]
 [ext_resource type="FontFile" uid="uid://cvuth304y1byc" path="res://assets/fonts/tinypixel.ttf" id="6_7tixs"]
@@ -9,24 +8,6 @@
 
 [node name="TestInventory" type="Node2D" unique_id=1879085168]
 script = ExtResource("1_372ms")
-
-[node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=755010616]
-layer = -1
-
-[node name="Inventory" parent="CanvasLayer" unique_id=1443629152 node_paths=PackedStringArray("node_to_drop") instance=ExtResource("2_i0jss")]
-visible = false
-anchors_preset = 11
-anchor_left = 1.0
-anchor_top = 0.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -60.0
-offset_top = 0.0
-offset_right = -60.0
-offset_bottom = 0.0
-grow_horizontal = 0
-dimensions = Vector2i(3, 3)
-node_to_drop = NodePath("../../Droper")
 
 [node name="Carne" parent="." unique_id=1998340507 instance=ExtResource("3_2ff5v")]
 position = Vector2(224, 120)
@@ -100,26 +81,3 @@ text = "Press I for Inventory"
 
 [node name="Player" parent="." unique_id=1328809556 instance=ExtResource("6_67sjd")]
 position = Vector2(146.00002, 108)
-
-[node name="Droper" type="Marker2D" parent="." unique_id=878080529]
-position = Vector2(146.28539, 172.08502)
-
-[node name="Label" type="Label" parent="Droper" unique_id=700499900]
-texture_filter = 1
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = -27.285385
-offset_top = 1.9149628
-offset_right = 27.42923
-offset_bottom = 24.914963
-grow_horizontal = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/line_spacing = 2
-theme_override_constants/paragraph_spacing = 0
-theme_override_constants/outline_size = 3
-theme_override_fonts/font = ExtResource("6_7tixs")
-theme_override_font_sizes/font_size = 5
-text = "drop area"
-horizontal_alignment = 1
-vertical_alignment = 1


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Relacionado a: #15 
Closes #15 

- Criado StackableComponent e implementado Stack no inventário (merge, split, pickup parcial com Shift)
- Loja agora respeita stacks: can_add_buy_item considera espaço em stacks existentes, confirm_buy transfere todas as unidades, undo_buy_item decrementa em vez de remover
- Corrigido bug na compra mesmo com o inventario de transferencia cheio (aparecia um item no canto superior esquerdo) e sincronia de counts do item no espelho do inventário do jogador no shop
- Venda por cliques (sem drag): esquerdo = 1 unidade, direito = metade, Shift+esquerdo = stack inteiro; remove_real_player_item decrementa em vez de remover tudo
- can_drop_items para separar movimento de drop; todos os inventários do shop com can_drop_items=false, can_move_items=false, e sinais de split/drop desconectados

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ v ] Lógica (.gd): Scripts alterados/adicionados.

[ v ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ x ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ x ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ v ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ v ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ v ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ v ] Testado no Editor (Desktop).

[ x ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).