### PR TITLE
feat(tanajura):tanajura movementadjust

### DIFF
--- a/Game-Loot-Lunch/entities/enemies/tanajura/formigueiro.gd
+++ b/Game-Loot-Lunch/entities/enemies/tanajura/formigueiro.gd
@@ -6,6 +6,7 @@ class_name Formigueiro
 
 
 @onready var collision_shape: CollisionShape2D = $Area2D/CollisionShape2D
+@onready var entrance: CollisionShape2D = $EntranceStaticBody2D/CollisionShape2D
 
 
 func _on_spawned(spawned_creature: Character) -> void:

--- a/Game-Loot-Lunch/entities/enemies/tanajura/formigueiro.tscn
+++ b/Game-Loot-Lunch/entities/enemies/tanajura/formigueiro.tscn
@@ -24,9 +24,9 @@ texture = ExtResource("3_18rgx")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D" unique_id=1757321901]
 shape = SubResource("CircleShape2D_m5uyx")
 
-[node name="StaticBody2D" type="StaticBody2D" parent="." unique_id=742201568]
+[node name="EntranceStaticBody2D" type="StaticBody2D" parent="." unique_id=742201568]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D" unique_id=428512892]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="EntranceStaticBody2D" unique_id=428512892]
 shape = SubResource("CircleShape2D_18rgx")
 
 [connection signal="spawned" from="." to="." method="_on_spawned"]

--- a/Game-Loot-Lunch/entities/enemies/tanajura/fsm/tanajura_fsm.gd
+++ b/Game-Loot-Lunch/entities/enemies/tanajura/fsm/tanajura_fsm.gd
@@ -37,6 +37,9 @@ func _get_transition() -> int:
 					return states.idle
 				else:
 					return states.chase
+		states.chase:
+			if parent.states_timer.is_stopped() and !parent.alert:
+				return states.idle
 		states.hidden:
 			if parent.alert:
 				return states.digging_up
@@ -55,7 +58,6 @@ func _get_transition() -> int:
 
 
 func _enter_state(_previous_state: int, new_state: int) -> void:
-	print(states.find_key(state))
 	match new_state:
 		states.idle:
 			parent.idle_state()
@@ -81,3 +83,4 @@ func _exit_state(state_exited: int) -> void:
 	match state_exited:
 		states.hidden:
 			parent.hidden_move()
+		

--- a/Game-Loot-Lunch/entities/enemies/tanajura/tanajura.gd
+++ b/Game-Loot-Lunch/entities/enemies/tanajura/tanajura.gd
@@ -67,7 +67,7 @@ func dead_state() -> void:
 func hidden_move() -> void:
 	if formigueiro:
 		angle = randf_range(0.0, TAU)
-		radius = randi_range(0, formigueiro.collision_shape.shape.radius)
+		radius = randi_range(formigueiro.entrance.shape.radius, formigueiro.collision_shape.shape.radius)
 		position = Vector2(cos(angle), sin(angle)) * radius
 
 
@@ -75,12 +75,17 @@ func _on_territory_body_entered(_body: Node2D) -> void:
 	if !state_machine.states["chase"] == state_machine.state:
 		alert = true
 		flip_sprite_component.node_to_face = chase_component.chased_node
+	else:
+		alert = true
 
 
 func _on_territory_body_exited(_body: Node2D) -> void:
+	alert = false
+	
 	if !state_machine.states["chase"] == state_machine.state:
-		alert = false
 		flip_sprite_component.node_to_face = null
+	else:
+		states_timer.start(5)
 
 
 func _on_chase_component_next_chase_point_set(next_point: Vector2) -> void:


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Relacionado a: # (Link da issue/task)

- added logic to stop chasing when the player exits tanajura's alert area

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x: 

[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

[ :heavy_check_mark: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).